### PR TITLE
Allow customizing element list (can start from H2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,63 @@
 # Automatically Structured Headings [![Build Status](https://travis-ci.org/PolicyStat/ckeditor-plugin-structured-headings.svg?branch=master)](https://travis-ci.org/PolicyStat/ckeditor-plugin-structured-headings)
 ## Configuration Options
+### numberedElements
+Array of elements (in order) that will be a part of numbering.
+array, default:
+```
+[
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6"
+];
+```
 ### autonumberBaseClass
-Base CSS class to apply to any autonumbered heading.
+Base CSS class to apply to any autonumbered heading. Also appended with the index number of the
+current level. H1 = autonumber-0, H2 = autonumber-1, etc.
 string, default: `"autonumber"`
 ### autonumberRestartClass
 CSS class to add to any heading to restart numbering at that point.
 string, default: `"autonumber-restart"`
 ### autonumberStyles
-Listing of style definitions by name, each specifying what additional CSS
-class to apply to each header element. A value of `null` signifies using the
-BaseClass only.
+Listing of style definitions by name, each style definition is an array specifying what additional
+CSS class to apply to each index level of the element as specified in numberedElements.
 object, default:
 ```
 { 
-  Default: null,
-  Narara: {
-    h1: "autonumber-N",
-    h2: "autonumber-a",
-    h3: "autonumber-r",
-    h4: "autonumber-a",
-    h5: "autonumber-r",
-    h6: "autonumber-a"
-  },
-  Aarara: {
-    h1: "autonumber-A",
-    h2: "autonumber-a",
-    h3: "autonumber-r",
-    h4: "autonumber-a",
-    h5: "autonumber-r",
-    h6: "autonumber-a"
-  },
-  RANaNa: {
-    h1: "autonumber-R",
-    h2: "autonumber-A",
-    h3: "autonumber-N",
-    h4: "autonumber-a",
-    h5: "autonumber-N",
-    h6: "autonumber-a"
-  }
+  "Numeric": [
+    "autonumber-0",
+    "autonumber-1",
+    "autonumber-2",
+    "autonumber-3",
+    "autonumber-4",
+    "autonumbe4-5"
+  ],
+  "Number Lowercase Roman": [
+    "autonumber-N",
+    "autonumber-a",
+    "autonumber-r",
+    "autonumber-a",
+    "autonumber-r",
+    "autonumber-a"
+  ],
+  "Letter Lowercase Roman": [
+    "autonumber-A",
+    "autonumber-a",
+    "autonumber-r",
+    "autonumber-a",
+    "autonumber-r",
+    "autonumber-a"
+  ],
+  "Roman Uppercase Number": [
+    "autonumber-R",
+    "autonumber-A",
+    "autonumber-N",
+    "autonumber-a",
+    "autonumber-N",
+    "autonumber-a"
+  ]
 }
 ```
 ### autonumberStyleImages
@@ -54,4 +74,4 @@ object, default:
 ```
 ### autonumberCurrentStyle
 The name of the currently active style to be applied.
-string, default: `"Default"`
+string, default: `"Numeric"`

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -291,7 +291,7 @@
           var previousHeader = getPreviousHeader(editor, editor.elementPath().block);
 
         // if already in header, set back to default based on enter mode
-          if (editor.elementPath().block.is(editor.config.allowedElements)) {
+          if (editor.config.numberedElements.indexOf(editor.elementPath().block.getName()) >= 0) {
             if (editor.config.enterMode === CKEDITOR.ENTER_DIV) {
               editor.applyStyle(elementStyles.div);
             } else {

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -353,8 +353,9 @@
         //eslint-disable-next-line new-cap
           var style = new CKEDITOR.style({ element: nextElement});
           editor.applyStyle(style);
-          if(isNumbered(editor, element))
+          if (isNumbered(editor, element)) {
             setStyle(editor, editor.elementPath().block, editor.config.autonumberCurrentStyle);
+          }
         },
         refresh: function (editor, path) {
           if (path.block && editor.config.numberedElements.indexOf(path.block.getName()) >= 0) {
@@ -393,8 +394,9 @@
         //eslint-disable-next-line new-cap
           var style = new CKEDITOR.style({ element: prevElement});
           editor.applyStyle(style);
-          if(isNumbered(editor, element))
+          if (isNumbered(editor, element)) {
             setStyle(editor, editor.elementPath().block, editor.config.autonumberCurrentStyle);
+          }
         },
         refresh: function (editor, path) {
           if (path.block && editor.config.numberedElements.indexOf(path.block.getName()) >= 0) {

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -20,6 +20,13 @@
 
 //style helpers
 
+  var isNumbered = function (editor, element) {
+    if (element.hasClass(editor.config.autonumberBaseClass)) {
+      return true;
+    } else {
+      return false;
+    }
+  };
 
   var clearStyles = function (editor, element) {
     for (var styleName in editor.config.autonumberStyles) {
@@ -42,14 +49,6 @@
       }
     }
 
-  };
-
-  var isNumbered = function (editor, element) {
-    if (element.hasClass(editor.config.autonumberBaseClass)) {
-      return true;
-    } else {
-      return false;
-    }
   };
 
   var getPreviousHeader = function (editor, element) {

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -6,7 +6,7 @@
   var setupElements = function (editor) {
 
     // list of elements allowed to be numbered
-    editor.config.numberedElements = 
+    editor.config.numberedElements =
     editor.config.numberedElements || [
       "h1",
       "h2",

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -41,8 +41,7 @@
     var style = editor.config.autonumberStyles[styleName];
     if (element.type === CKEDITOR.NODE_ELEMENT) {
       clearStyles(editor, element);
-      if (isNumbered(editor, element) &&
-      style && style[editor.config.numberedElements.indexOf(element.getName())]) {
+      if (style && style[editor.config.numberedElements.indexOf(element.getName())]) {
         element.addClass(editor.config.autonumberBaseClass + "-" +
           editor.config.numberedElements.indexOf(element.getName()));
         element.addClass(style[editor.config.numberedElements.indexOf(element.getName())]);
@@ -354,7 +353,8 @@
         //eslint-disable-next-line new-cap
           var style = new CKEDITOR.style({ element: nextElement});
           editor.applyStyle(style);
-          setStyle(editor, editor.elementPath().block, editor.config.autonumberCurrentStyle);
+          if(isNumbered(editor, element))
+            setStyle(editor, editor.elementPath().block, editor.config.autonumberCurrentStyle);
         },
         refresh: function (editor, path) {
           if (path.block && editor.config.numberedElements.indexOf(path.block.getName()) >= 0) {
@@ -393,7 +393,8 @@
         //eslint-disable-next-line new-cap
           var style = new CKEDITOR.style({ element: prevElement});
           editor.applyStyle(style);
-          setStyle(editor, editor.elementPath().block, editor.config.autonumberCurrentStyle);
+          if(isNumbered(editor, element))
+            setStyle(editor, editor.elementPath().block, editor.config.autonumberCurrentStyle);
         },
         refresh: function (editor, path) {
           if (path.block && editor.config.numberedElements.indexOf(path.block.getName()) >= 0) {

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -41,7 +41,7 @@
     var style = editor.config.autonumberStyles[styleName];
     if (element.type === CKEDITOR.NODE_ELEMENT) {
       clearStyles(editor, element);
-      if (isNumbered(element) &&
+      if (isNumbered(editor, element) &&
       style && style[editor.config.numberedElements.indexOf(element.getName())]) {
         element.addClass(editor.config.autonumberBaseClass + "-" +
           editor.config.numberedElements.indexOf(element.getName()));

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -3,20 +3,20 @@
  * Helper Functions
  */
 
-// list of elements allowed to be numbered
-  var allowedElements = {
-    h1: 1,
-    h2: 1,
-    h3: 1,
-    h4: 1,
-    h5: 1,
-    h6: 1
-  };
+  var setupElements = function (editor) {
 
-//some friendly setup for level changes
-  var headerList = ["h1", "h2", "h3", "h4", "h5", "h6"];
-  var firstHeaderKey = 0;
-  var lastHeaderKey = headerList.length - 1;
+    // list of elements allowed to be numbered
+    editor.config.numberedElements = 
+    editor.config.numberedElements || [
+      "h1",
+      "h2",
+      "h3",
+      "h4",
+      "h5",
+      "h6"
+    ];
+
+  };
 
 //style helpers
 
@@ -34,8 +34,10 @@
     var style = editor.config.autonumberStyles[styleName];
     if (element.type === CKEDITOR.NODE_ELEMENT) {
       clearStyles(editor, element);
-      if (style && style[element.getName()]) {
-        element.addClass(style[element.getName()]);
+      if (style && style[editor.config.numberedElements.indexOf(element.getName())]) {
+        element.addClass(editor.config.autonumberBaseClass + "-" +
+          editor.config.numberedElements.indexOf(element.getName()));
+        element.addClass(style[editor.config.numberedElements.indexOf(element.getName())]);
       }
     }
 
@@ -49,10 +51,10 @@
     }
   };
 
-  var getPreviousHeader = function (element) {
+  var getPreviousHeader = function (editor, element) {
     return element.getPrevious(function (node) {
       if (node.type === CKEDITOR.NODE_ELEMENT &&
-        node.is(allowedElements)
+        editor.config.numberedElements.indexOf(node.getName()) >= 0
     ) {
         return true;
       } else {
@@ -136,31 +138,38 @@
 
     editor.config.autonumberStyles =
     editor.config.autonumberStyles || {
-      "Numeric": null,
-      "Number Lowercase Roman": {
-        h1: "autonumber-N",
-        h2: "autonumber-a",
-        h3: "autonumber-r",
-        h4: "autonumber-a",
-        h5: "autonumber-r",
-        h6: "autonumber-a"
-      },
-      "Letter Lowercase Roman": {
-        h1: "autonumber-A",
-        h2: "autonumber-a",
-        h3: "autonumber-r",
-        h4: "autonumber-a",
-        h5: "autonumber-r",
-        h6: "autonumber-a"
-      },
-      "Roman Uppercase Number": {
-        h1: "autonumber-R",
-        h2: "autonumber-A",
-        h3: "autonumber-N",
-        h4: "autonumber-a",
-        h5: "autonumber-N",
-        h6: "autonumber-a"
-      }
+      "Numeric": [
+        "autonumber-0",
+        "autonumber-1",
+        "autonumber-2",
+        "autonumber-3",
+        "autonumber-4",
+        "autonumbe4-5"
+      ],
+      "Number Lowercase Roman": [
+        "autonumber-N",
+        "autonumber-a",
+        "autonumber-r",
+        "autonumber-a",
+        "autonumber-r",
+        "autonumber-a"
+      ],
+      "Letter Lowercase Roman": [
+        "autonumber-A",
+        "autonumber-a",
+        "autonumber-r",
+        "autonumber-a",
+        "autonumber-r",
+        "autonumber-a"
+      ],
+      "Roman Uppercase Number": [
+        "autonumber-R",
+        "autonumber-A",
+        "autonumber-N",
+        "autonumber-a",
+        "autonumber-N",
+        "autonumber-a"
+      ]
     };
 
     editor.config.autonumberStyleImages =
@@ -190,6 +199,7 @@
       editor.config.autonumberStyleImgPath = this.path + "dialogs/img";
       editor.addContentsCss(this.path + "styles/numbering.css");
 
+      setupElements(editor);
       setupCommands(editor);
       addButtons(editor);
       setupStyles(editor);
@@ -241,7 +251,7 @@
 
         },
         refresh: function (editor, path) {
-          if (path.block && path.block.is(allowedElements)) {
+          if (path.block && editor.config.numberedElements.indexOf(path.block.getName()) >= 0) {
             if (isNumbered(editor, path.block)) {
               this.setState(CKEDITOR.TRISTATE_ON);
             } else {
@@ -278,10 +288,10 @@
             //eslint-disable-next-line new-cap
             h6: new CKEDITOR.style({ element: "h6" })
           };
-          var previousHeader = getPreviousHeader(editor.elementPath().block);
+          var previousHeader = getPreviousHeader(editor, editor.elementPath().block);
 
         // if already in header, set back to default based on enter mode
-          if (editor.elementPath().block.is(allowedElements)) {
+          if (editor.elementPath().block.is(editor.config.allowedElements)) {
             if (editor.config.enterMode === CKEDITOR.ENTER_DIV) {
               editor.applyStyle(elementStyles.div);
             } else {
@@ -299,17 +309,18 @@
               setStyle(editor, editor.elementPath().block, editor.config.autonumberCurrentStyle);
             }
 
-        // else set it as new H1
+        // else set it as new first element
           } else {
-            editor.applyStyle(elementStyles.h1);
+            editor.applyStyle(elementStyles[editor.config.numberedElements[0]]);
+
             //editor.elementPath().block.addClass(editor.config.autonumberBaseClass);
             //setStyle(editor, editor.elementPath().block, editor.config.autonumberCurrentStyle);
           }
         },
         refresh: function (editor, path) {
-          if (path.block && path.block.is(allowedElements)) {
+          if (path.block && editor.config.numberedElements.indexOf(path.block.getName()) >= 0) {
             this.setState(CKEDITOR.TRISTATE_ON);
-          } else if (path.block && path.block.is({p: 1})) {
+          } else if (path.block && path.block.is({h1: 1, p: 1})) {
             this.setState(CKEDITOR.TRISTATE_OFF);
           } else {
             this.setState(CKEDITOR.TRISTATE_DISABLED);
@@ -325,13 +336,17 @@
         startDisabled: true,
         exec: function (editor) {
           var element = editor.elementPath().block;
-          var nextElement = headerList[headerList.indexOf(element.getName()) + 1];
+          var nextElement = editor.config.numberedElements[editor.config.numberedElements.indexOf(
+            element.getName()) + 1];
 
         //set a maximum level of the previous level + 1
-          var previousHeader = getPreviousHeader(element);
+          var previousHeader = getPreviousHeader(editor, element);
+
           if (previousHeader) {
-            var maxElement = headerList[headerList.indexOf(previousHeader.getName()) + 1];
-            if (headerList.indexOf(nextElement) > headerList.indexOf(maxElement)) {
+            var maxElement = editor.config.numberedElements[editor.config.numberedElements.indexOf(
+              previousHeader.getName()) + 1];
+            if (editor.config.numberedElements.indexOf(nextElement) >
+              editor.config.numberedElements.indexOf(maxElement)) {
               nextElement = maxElement;
             }
           }
@@ -342,14 +357,16 @@
           setStyle(editor, editor.elementPath().block, editor.config.autonumberCurrentStyle);
         },
         refresh: function (editor, path) {
-          if (path.block && path.block.is(allowedElements)) {
-            var previousHeader = getPreviousHeader(path.block);
+          if (path.block && editor.config.numberedElements.indexOf(path.block.getName()) >= 0) {
+            var previousHeader = getPreviousHeader(editor, path.block);
 
-            if (lastHeaderKey === headerList.indexOf(path.block.getName())) {
+            if (editor.config.numberedElements.length - 1 ===
+              editor.config.numberedElements.indexOf(path.block.getName())) {
               this.setState(CKEDITOR.TRISTATE_DISABLED);
             } else if (
             previousHeader && path.block.getName() ===
-            headerList[headerList.indexOf(previousHeader.getName()) + 1]
+            editor.config.numberedElements[editor.config.numberedElements.indexOf(
+              previousHeader.getName()) + 1]
           ) {
               this.setState(CKEDITOR.TRISTATE_DISABLED);
             } else {
@@ -371,15 +388,16 @@
         startDisabled: true,
         exec: function (editor) {
           var element = editor.elementPath().block;
-          var prevElement = headerList[headerList.indexOf(element.getName()) - 1];
+          var prevElement = editor.config.numberedElements[editor.config.numberedElements.indexOf(
+            element.getName()) - 1];
         //eslint-disable-next-line new-cap
           var style = new CKEDITOR.style({ element: prevElement});
           editor.applyStyle(style);
           setStyle(editor, editor.elementPath().block, editor.config.autonumberCurrentStyle);
         },
         refresh: function (editor, path) {
-          if (path.block && path.block.is(allowedElements)) {
-            if (firstHeaderKey === headerList.indexOf(path.block.getName())) {
+          if (path.block && editor.config.numberedElements.indexOf(path.block.getName()) >= 0) {
+            if (editor.config.numberedElements.indexOf(path.block.getName()) === 0) {
               this.setState(CKEDITOR.TRISTATE_DISABLED);
             } else {
               this.setState(CKEDITOR.TRISTATE_OFF);
@@ -410,7 +428,7 @@
           }
         },
         refresh: function (editor, path) {
-          if (path.block && path.block.is({h1: 1})) {
+          if (path.block && path.block.getName() === editor.config.numberedElements[0]) {
             if (path.block.hasClass(editor.config.autonumberRestartClass)) {
               this.setState(CKEDITOR.TRISTATE_ON);
             } else {

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -34,7 +34,8 @@
     var style = editor.config.autonumberStyles[styleName];
     if (element.type === CKEDITOR.NODE_ELEMENT) {
       clearStyles(editor, element);
-      if (style && style[editor.config.numberedElements.indexOf(element.getName())]) {
+      if (isNumbered(element) &&
+      style && style[editor.config.numberedElements.indexOf(element.getName())]) {
         element.addClass(editor.config.autonumberBaseClass + "-" +
           editor.config.numberedElements.indexOf(element.getName()));
         element.addClass(style[editor.config.numberedElements.indexOf(element.getName())]);

--- a/structuredheadings/styles/numbering.css
+++ b/structuredheadings/styles/numbering.css
@@ -1,48 +1,48 @@
 /* Counter Configuration */
 body {
-    counter-reset: h1 h2 h3 h4 h5 h6;
+    counter-reset: autonumber-0 autonumber-1 autonumber-2 autonumber-3 autonumber-4 autonumber-5;
 }
 .autonumber.autonumber-0 {
-    counter-increment: h1;
-    counter-reset: h2;
+    counter-increment: autonumber-0;
+    counter-reset: autonumber-1;
 }
 .autonumber.autonumber-1 {
-	counter-increment: h2;
-	counter-reset: h3;
+	counter-increment: autonumber-1;
+	counter-reset: autonumber-2;
 }
 .autonumber.autonumber-2 {
-	counter-increment: h3;
-	counter-reset: h4;
+	counter-increment: autonumber-2;
+	counter-reset: autonumber-3;
 }
 .autonumber.autonumber-3 {
-	counter-increment: h4;
-	counter-reset: h5;
+	counter-increment: autonumber-3;
+	counter-reset: autonumber-4;
 }
 .autonumber.autonumber-4 {
-	counter-increment: h5;
-	counter-reset: h6;
+	counter-increment: autonumber-4;
+	counter-reset: autonumber-5;
 }
 .autonumber.autonumber-5 {
-	counter-increment: h6;
+	counter-increment: autonumber-5;
 }
 
 .autonumber.autonumber-0.autonumber-restart {
-	counter-reset: h1;
+	counter-reset: autonumber-0;
 }
 .autonumber.autonumber-1.autonumber-restart {
-  counter-reset: h2;
+  counter-reset: autonumber-1;
 }
 .autonumber.autonumber-2.autonumber-restart {
-  counter-reset: h3;
+  counter-reset: autonumber-2;
 }
 .autonumber.autonumber-3.autonumber-restart {
-  counter-reset: h4;
+  counter-reset: autonumber-3;
 }
 .autonumber.autonumber-4.autonumber-restart {
-  counter-reset: h5;
+  counter-reset: autonumber-4;
 }
 .autonumber.autonumber-5.autonumber-restart {
-  counter-reset: h6;
+  counter-reset: autonumber-5;
 }
 
 
@@ -56,125 +56,125 @@ body {
 
 /* Default */
 .autonumber.autonumber-0:before {
-    content: counter(h1) ". ";
+    content: counter(autonumber-0) ". ";
 }
 .autonumber.autonumber-1:before {
-    content: counter(h1) "." counter(h2) ". ";
+    content: counter(autonumber-0) "." counter(autonumber-1) ". ";
 }
 .autonumber.autonumber-2:before {
-    content: counter(h1) "." counter(h2) "." counter(h3) ". ";
+    content: counter(autonumber-0) "." counter(autonumber-1) "." counter(autonumber-2) ". ";
 }
 .autonumber.autonumber-3:before {
-    content: counter(h1) "." counter(h2) "." counter(h3) "." counter(h4) ". ";
+    content: counter(autonumber-0) "." counter(autonumber-1) "." counter(autonumber-2) "." counter(autonumber-3) ". ";
 }
 .autonumber.autonumber-4:before {
-    content: counter(h1) "." counter(h2) "." counter(h3) "." counter(h4) "." counter(h5) ". ";
+    content: counter(autonumber-0) "." counter(autonumber-1) "." counter(autonumber-2) "." counter(autonumber-3) "." counter(autonumber-4) ". ";
 }
 .autonumber.autonumber-5:before {
-    content: counter(h1) "." counter(h2) "." counter(h3) "." counter(h4) "." counter(h5) "." counter(h6) ". ";
+    content: counter(autonumber-0) "." counter(autonumber-1) "." counter(autonumber-2) "." counter(autonumber-3) "." counter(autonumber-4) "." counter(autonumber-5) ". ";
 }
 
 /* N */
 
 .autonumber.autonumber-0.autonumber-N:before {
-    content: counter(h1) ". ";
+    content: counter(autonumber-0) ". ";
 }
 .autonumber.autonumber-1.autonumber-N:before {
-    content: counter(h2) ". ";
+    content: counter(autonumber-1) ". ";
 }
 .autonumber.autonumber-2.autonumber-N:before {
-    content: counter(h3) ". ";
+    content: counter(autonumber-2) ". ";
 }
 .autonumber.autonumber-3.autonumber-N:before {
-    content: counter(h4) ". ";
+    content: counter(autonumber-3) ". ";
 }
 .autonumber.autonumber-4.autonumber-N:before {
-    content: counter(h5) ". ";
+    content: counter(autonumber-4) ". ";
 }
 .autonumber.autonumber-5.autonumber-N:before {
-    content: counter(h6) ". ";
+    content: counter(autonumber-5) ". ";
 }
 
 /* A */
 
 .autonumber.autonumber-0.autonumber-A:before {
-    content: counter(h1, upper-alpha) ". ";
+    content: counter(autonumber-0, upper-alpha) ". ";
 }
 .autonumber.autonumber-1.autonumber-A:before {
-    content: counter(h2, upper-alpha) ". ";
+    content: counter(autonumber-1, upper-alpha) ". ";
 }
 .autonumber.autonumber-2.autonumber-A:before {
-    content: counter(h3, upper-alpha) ". ";
+    content: counter(autonumber-2, upper-alpha) ". ";
 }
 .autonumber.autonumber-3.autonumber-A:before {
-    content: counter(h4, upper-alpha) ". ";
+    content: counter(autonumber-3, upper-alpha) ". ";
 }
 .autonumber.autonumber-4.autonumber-A:before {
-    content: counter(h5, upper-alpha) ". ";
+    content: counter(autonumber-4, upper-alpha) ". ";
 }
 .autonumber.autonumber-5.autonumber-A:before {
-    content: counter(h6, upper-alpha) ". ";
+    content: counter(autonumber-5, upper-alpha) ". ";
 }
 
 /* a */
 
 .autonumber.autonumber-0.autonumber-a:before {
-    content: counter(h1, lower-alpha) ". ";
+    content: counter(autonumber-0, lower-alpha) ". ";
 }
 .autonumber.autonumber-1.autonumber-a:before {
-    content: counter(h2, lower-alpha) ". ";
+    content: counter(autonumber-1, lower-alpha) ". ";
 }
 .autonumber.autonumber-2.autonumber-a:before {
-    content: counter(h3, lower-alpha) ". ";
+    content: counter(autonumber-2, lower-alpha) ". ";
 }
 .autonumber.autonumber-3.autonumber-a:before {
-    content: counter(h4, lower-alpha) ". ";
+    content: counter(autonumber-3, lower-alpha) ". ";
 }
 .autonumber.autonumber-4.autonumber-a:before {
-    content: counter(h5, lower-alpha) ". ";
+    content: counter(autonumber-4, lower-alpha) ". ";
 }
 .autonumber.autonumber-5.autonumber-a:before {
-    content: counter(h6, lower-alpha) ". ";
+    content: counter(autonumber-5, lower-alpha) ". ";
 }
 
 /* R */
 
 .autonumber.autonumber-0.autonumber-R:before {
-    content: counter(h1, upper-roman) ". ";
+    content: counter(autonumber-0, upper-roman) ". ";
 }
 .autonumber.autonumber-1.autonumber-R:before {
-    content: counter(h2, upper-roman) ". ";
+    content: counter(autonumber-1, upper-roman) ". ";
 }
 .autonumber.autonumber-2.autonumber-R:before {
-    content: counter(h3, upper-roman) ". ";
+    content: counter(autonumber-2, upper-roman) ". ";
 }
 .autonumber.autonumber-3.autonumber-R:before {
-    content: counter(h4, upper-roman) ". ";
+    content: counter(autonumber-3, upper-roman) ". ";
 }
 .autonumber.autonumber-4.autonumber-R:before {
-    content: counter(h5, upper-roman) ". ";
+    content: counter(autonumber-4, upper-roman) ". ";
 }
 .autonumber.autonumber-5.autonumber-R:before {
-    content: counter(h6, upper-roman) ". ";
+    content: counter(autonumber-5, upper-roman) ". ";
 }
 
 /* r */
 
 .autonumber.autonumber-0.autonumber-r:before {
-    content: counter(h1, lower-roman) ". ";
+    content: counter(autonumber-0, lower-roman) ". ";
 }
 .autonumber.autonumber-1.autonumber-r:before {
-    content: counter(h2, lower-roman) ". ";
+    content: counter(autonumber-1, lower-roman) ". ";
 }
 .autonumber.autonumber-2.autonumber-r:before {
-    content: counter(h3, lower-roman) ". ";
+    content: counter(autonumber-2, lower-roman) ". ";
 }
 .autonumber.autonumber-3.autonumber-r:before {
-    content: counter(h4, lower-roman) ". ";
+    content: counter(autonumber-3, lower-roman) ". ";
 }
 .autonumber.autonumber-4.autonumber-r:before {
-    content: counter(h5, lower-roman) ". ";
+    content: counter(autonumber-4, lower-roman) ". ";
 }
 .autonumber.autonumber-5.autonumber-r:before {
-    content: counter(h6, lower-roman) ". ";
+    content: counter(autonumber-5, lower-roman) ". ";
 }

--- a/structuredheadings/styles/numbering.css
+++ b/structuredheadings/styles/numbering.css
@@ -2,32 +2,47 @@
 body {
     counter-reset: h1 h2 h3 h4 h5 h6;
 }
-h1.autonumber {
+.autonumber.autonumber-0 {
     counter-increment: h1;
     counter-reset: h2;
 }
-h2.autonumber {
+.autonumber.autonumber-1 {
 	counter-increment: h2;
 	counter-reset: h3;
 }
-h3.autonumber {
+.autonumber.autonumber-2 {
 	counter-increment: h3;
 	counter-reset: h4;
 }
-h4.autonumber {
+.autonumber.autonumber-3 {
 	counter-increment: h4;
 	counter-reset: h5;
 }
-h5.autonumber {
+.autonumber.autonumber-4 {
 	counter-increment: h5;
 	counter-reset: h6;
 }
-h6.autonumber {
+.autonumber.autonumber-5 {
 	counter-increment: h6;
 }
 
-h1.autonumber-restart {
+.autonumber.autonumber-0.autonumber-restart {
 	counter-reset: h1;
+}
+.autonumber.autonumber-1.autonumber-restart {
+  counter-reset: h2;
+}
+.autonumber.autonumber-2.autonumber-restart {
+  counter-reset: h3;
+}
+.autonumber.autonumber-3.autonumber-restart {
+  counter-reset: h4;
+}
+.autonumber.autonumber-4.autonumber-restart {
+  counter-reset: h5;
+}
+.autonumber.autonumber-5.autonumber-restart {
+  counter-reset: h6;
 }
 
 
@@ -40,126 +55,126 @@ h1.autonumber-restart {
  */
 
 /* Default */
-h1.autonumber:before {
+.autonumber.autonumber-0:before {
     content: counter(h1) ". ";
 }
-h2.autonumber:before {
+.autonumber.autonumber-1:before {
     content: counter(h1) "." counter(h2) ". ";
 }
-h3.autonumber:before {
+.autonumber.autonumber-2:before {
     content: counter(h1) "." counter(h2) "." counter(h3) ". ";
 }
-h4.autonumber:before {
+.autonumber.autonumber-3:before {
     content: counter(h1) "." counter(h2) "." counter(h3) "." counter(h4) ". ";
 }
-h5.autonumber:before {
+.autonumber.autonumber-4:before {
     content: counter(h1) "." counter(h2) "." counter(h3) "." counter(h4) "." counter(h5) ". ";
 }
-h6.autonumber:before {
+.autonumber.autonumber-5:before {
     content: counter(h1) "." counter(h2) "." counter(h3) "." counter(h4) "." counter(h5) "." counter(h6) ". ";
 }
 
 /* N */
 
-h1.autonumber.autonumber-N:before {
+.autonumber.autonumber-0.autonumber-N:before {
     content: counter(h1) ". ";
 }
-h2.autonumber.autonumber-N:before {
+.autonumber.autonumber-1.autonumber-N:before {
     content: counter(h2) ". ";
 }
-h3.autonumber.autonumber-N:before {
+.autonumber.autonumber-2.autonumber-N:before {
     content: counter(h3) ". ";
 }
-h4.autonumber.autonumber-N:before {
+.autonumber.autonumber-3.autonumber-N:before {
     content: counter(h4) ". ";
 }
-h5.autonumber.autonumber-N:before {
+.autonumber.autonumber-4.autonumber-N:before {
     content: counter(h5) ". ";
 }
-h6.autonumber.autonumber-N:before {
+.autonumber.autonumber-5.autonumber-N:before {
     content: counter(h6) ". ";
 }
 
 /* A */
 
-h1.autonumber.autonumber-A:before {
+.autonumber.autonumber-0.autonumber-A:before {
     content: counter(h1, upper-alpha) ". ";
 }
-h2.autonumber.autonumber-A:before {
+.autonumber.autonumber-1.autonumber-A:before {
     content: counter(h2, upper-alpha) ". ";
 }
-h3.autonumber.autonumber-A:before {
+.autonumber.autonumber-2.autonumber-A:before {
     content: counter(h3, upper-alpha) ". ";
 }
-h4.autonumber.autonumber-A:before {
+.autonumber.autonumber-3.autonumber-A:before {
     content: counter(h4, upper-alpha) ". ";
 }
-h5.autonumber.autonumber-A:before {
+.autonumber.autonumber-4.autonumber-A:before {
     content: counter(h5, upper-alpha) ". ";
 }
-h6.autonumber.autonumber-A:before {
+.autonumber.autonumber-5.autonumber-A:before {
     content: counter(h6, upper-alpha) ". ";
 }
 
 /* a */
 
-h1.autonumber.autonumber-a:before {
+.autonumber.autonumber-0.autonumber-a:before {
     content: counter(h1, lower-alpha) ". ";
 }
-h2.autonumber.autonumber-a:before {
+.autonumber.autonumber-1.autonumber-a:before {
     content: counter(h2, lower-alpha) ". ";
 }
-h3.autonumber.autonumber-a:before {
+.autonumber.autonumber-2.autonumber-a:before {
     content: counter(h3, lower-alpha) ". ";
 }
-h4.autonumber.autonumber-a:before {
+.autonumber.autonumber-3.autonumber-a:before {
     content: counter(h4, lower-alpha) ". ";
 }
-h5.autonumber.autonumber-a:before {
+.autonumber.autonumber-4.autonumber-a:before {
     content: counter(h5, lower-alpha) ". ";
 }
-h6.autonumber.autonumber-a:before {
+.autonumber.autonumber-5.autonumber-a:before {
     content: counter(h6, lower-alpha) ". ";
 }
 
 /* R */
 
-h1.autonumber.autonumber-R:before {
+.autonumber.autonumber-0.autonumber-R:before {
     content: counter(h1, upper-roman) ". ";
 }
-h2.autonumber.autonumber-R:before {
+.autonumber.autonumber-1.autonumber-R:before {
     content: counter(h2, upper-roman) ". ";
 }
-h3.autonumber.autonumber-R:before {
+.autonumber.autonumber-2.autonumber-R:before {
     content: counter(h3, upper-roman) ". ";
 }
-h4.autonumber.autonumber-R:before {
+.autonumber.autonumber-3.autonumber-R:before {
     content: counter(h4, upper-roman) ". ";
 }
-h5.autonumber.autonumber-R:before {
+.autonumber.autonumber-4.autonumber-R:before {
     content: counter(h5, upper-roman) ". ";
 }
-h6.autonumber.autonumber-R:before {
+.autonumber.autonumber-5.autonumber-R:before {
     content: counter(h6, upper-roman) ". ";
 }
 
 /* r */
 
-h1.autonumber.autonumber-r:before {
+.autonumber.autonumber-0.autonumber-r:before {
     content: counter(h1, lower-roman) ". ";
 }
-h2.autonumber.autonumber-r:before {
+.autonumber.autonumber-1.autonumber-r:before {
     content: counter(h2, lower-roman) ". ";
 }
-h3.autonumber.autonumber-r:before {
+.autonumber.autonumber-2.autonumber-r:before {
     content: counter(h3, lower-roman) ". ";
 }
-h4.autonumber.autonumber-r:before {
+.autonumber.autonumber-3.autonumber-r:before {
     content: counter(h4, lower-roman) ". ";
 }
-h5.autonumber.autonumber-r:before {
+.autonumber.autonumber-4.autonumber-r:before {
     content: counter(h5, lower-roman) ". ";
 }
-h6.autonumber.autonumber-r:before {
+.autonumber.autonumber-5.autonumber-r:before {
     content: counter(h6, lower-roman) ". ";
 }

--- a/tests/structuredheadings/autonumber.js
+++ b/tests/structuredheadings/autonumber.js
@@ -24,6 +24,20 @@
 
     },
 
+    "AutoNumber Inactive in excluded Header Tag": function () {
+      var testCommand = this.editor.getCommand("autoNumberHeading");
+      var previousElements = this.editor.config.numberedElements;
+      this.editor.config.numberedElements = ["h2", "h3"];
+      this.editorBot.setHtmlWithSelection("<h1>^Heading</h1>");
+
+      assert.areSame(
+            CKEDITOR.TRISTATE_DISABLED, testCommand.state,
+            "autoNumberHeading DISABLED in excluded H1"
+          );
+      this.editor.config.numberedElements = previousElements;
+
+    },
+
     "AutoNumber Active and On Inside AutoNumbered Header": function () {
       this.editorBot.setHtmlWithSelection("<h1 class='autonumber'>^Heading</h1>");
       var testCommand = this.editor.getCommand("autoNumberHeading");

--- a/tests/structuredheadings/autonumber.js
+++ b/tests/structuredheadings/autonumber.js
@@ -53,7 +53,7 @@
       var updatedContent = bender.tools.getHtmlWithSelection(this.editorBot.editor);
 
       assert.areSame(
-      "<h1 class=\"autonumber autonumner-0\">^Heading</h1>", updatedContent,
+      "<h1 class=\"autonumber autonumber-0\">^Heading</h1>", updatedContent,
       "CSS class applied"
         );
       assert.areSame(

--- a/tests/structuredheadings/autonumber.js
+++ b/tests/structuredheadings/autonumber.js
@@ -53,7 +53,7 @@
       var updatedContent = bender.tools.getHtmlWithSelection(this.editorBot.editor);
 
       assert.areSame(
-      "<h1 class=\"autonumber\">^Heading</h1>", updatedContent,
+      "<h1 class=\"autonumber autonumner-0\">^Heading</h1>", updatedContent,
       "CSS class applied"
         );
       assert.areSame(

--- a/tests/structuredheadings/changelevel.js
+++ b/tests/structuredheadings/changelevel.js
@@ -94,12 +94,12 @@
     },
 
     "Increase doesn't affect numbering": function () {
-      this.editorBot.setHtmlWithSelection("<h2 class=\"autonumber autonumber-1\">^Heading</h2>");
+      this.editorBot.setHtmlWithSelection("<h2 class=\"autonumber autonumber-2\">^Heading</h2>");
       this.editorBot.execCommand("increaseHeadingLevel");
       var updatedContent = bender.tools.getHtmlWithSelection(this.editorBot.editor);
 
       assert.areSame(
-        "<h3 class=\"autonumber autonumber-1\">^Heading</h3>", updatedContent,
+        "<h3 class=\"autonumber autonumber-2\">^Heading</h3>", updatedContent,
         "Header Increased with Numbering Intact"
           );
     },

--- a/tests/structuredheadings/changelevel.js
+++ b/tests/structuredheadings/changelevel.js
@@ -13,6 +13,34 @@
       //Anything to be run before each test if needed
     },
 
+    "Decrease Inactive in H2 with excluded H1": function () {
+      var testCommand = this.editor.getCommand("decreaseHeadingLevel");
+      var previousElements = this.editor.config.numberedElements;
+      this.editor.config.numberedElements = ["h2", "h3"];
+      this.editorBot.setHtmlWithSelection("<h2>^Heading</h2>");
+
+      assert.areSame(
+            CKEDITOR.TRISTATE_DISABLED, testCommand.state,
+            "decreaseHeadingLevel DISABLED with excluded H1"
+          );
+      this.editor.config.numberedElements = previousElements;
+
+    },
+
+    "Increase Inactive in H5 with excluded H6": function () {
+      var testCommand = this.editor.getCommand("increaseHeadingLevel");
+      var previousElements = this.editor.config.numberedElements;
+      this.editor.config.numberedElements = ["h4", "h5"];
+      this.editorBot.setHtmlWithSelection("<h5>^Heading</h5>");
+
+      assert.areSame(
+              CKEDITOR.TRISTATE_DISABLED, testCommand.state,
+              "increaseHeadingLevel DISABLED with excluded H6"
+            );
+      this.editor.config.numberedElements = previousElements;
+
+    },
+
     "Increase and Decrease Level Disabled on P": function () {
       this.editorBot.setHtmlWithSelection("<p>^Paragraph</p>");
       var testCommand = this.editor.getCommand("increaseHeadingLevel");

--- a/tests/structuredheadings/changelevel.js
+++ b/tests/structuredheadings/changelevel.js
@@ -94,12 +94,12 @@
     },
 
     "Increase doesn't affect numbering": function () {
-      this.editorBot.setHtmlWithSelection("<h2 class=\"autonumber\">^Heading</h2>");
+      this.editorBot.setHtmlWithSelection("<h2 class=\"autonumber autonumber-1\">^Heading</h2>");
       this.editorBot.execCommand("increaseHeadingLevel");
       var updatedContent = bender.tools.getHtmlWithSelection(this.editorBot.editor);
 
       assert.areSame(
-        "<h3 class=\"autonumber\">^Heading</h3>", updatedContent,
+        "<h3 class=\"autonumber autonumber-1\">^Heading</h3>", updatedContent,
         "Header Increased with Numbering Intact"
           );
     },

--- a/tests/structuredheadings/matchheading.js
+++ b/tests/structuredheadings/matchheading.js
@@ -72,7 +72,7 @@
 
     "MatchHeading Updates P Tag to H2 and Autonumbered if Previous": function () {
       this.editorBot.setHtmlWithSelection(
-          "<h2 class=\"autonumber\">Header</h2>" +
+          "<h2 class=\"autonumber autonumber-1\">Header</h2>" +
           "<p>^Paragraph</p>"
         );
       this.editorBot.execCommand("matchHeading");

--- a/tests/structuredheadings/matchheading.js
+++ b/tests/structuredheadings/matchheading.js
@@ -79,8 +79,8 @@
       var updatedContent = bender.tools.getHtmlWithSelection(this.editorBot.editor);
 
       assert.areSame(
-          "<h2 class=\"autonumber\">Header</h2>" +
-          "<h2 class=\"autonumber\">^Paragraph</h2>", updatedContent,
+          "<h2 class=\"autonumber autonumber-1\">Header</h2>" +
+          "<h2 class=\"autonumber autonumber-1\">^Paragraph</h2>", updatedContent,
           "P changed to previous H2 autonumber"
         );
 

--- a/tests/structuredheadings/restartnumbering.js
+++ b/tests/structuredheadings/restartnumbering.js
@@ -49,19 +49,19 @@
       var updatedContent = bender.tools.getHtmlWithSelection(this.editorBot.editor);
 
       assert.areSame(
-        "<h1 class=\"autonumber autonumber-restart\">^Heading</h1>", updatedContent,
-        "Header Increased"
+        "<h1 class=\"autonumber autonumber-0 autonumber-restart\">^Heading</h1>", updatedContent,
+        "Header Numbered and Restarted"
           );
     },
 
     "Remove only restart class": function () {
       this.editorBot.setHtmlWithSelection(
-              "<h1 class=\"autonumber autonumber-restart\">^Heading</h1>");
+              "<h1 class=\"autonumber autonumber-0 autonumber-restart\">^Heading</h1>");
       this.editorBot.execCommand("restartNumbering");
       var updatedContent = bender.tools.getHtmlWithSelection(this.editorBot.editor);
 
       assert.areSame(
-          "<h1 class=\"autonumber\">^Heading</h1>", updatedContent,
+          "<h1 class=\"autonumber autonumber-0\">^Heading</h1>", updatedContent,
           "Header Decreased"
             );
     }

--- a/tests/structuredheadings/restartnumbering.js
+++ b/tests/structuredheadings/restartnumbering.js
@@ -49,7 +49,7 @@
       var updatedContent = bender.tools.getHtmlWithSelection(this.editorBot.editor);
 
       assert.areSame(
-        "<h1 class=\"autonumber autonumber-0 autonumber-restart\">^Heading</h1>", updatedContent,
+        "<h1 class=\"autonumber autonumber-restart autonumber-0\">^Heading</h1>", updatedContent,
         "Header Numbered and Restarted"
           );
     },

--- a/tests/structuredheadings/stylechooser.js
+++ b/tests/structuredheadings/stylechooser.js
@@ -25,13 +25,13 @@
     },
 
     "Style applied": function () {
-      this.editorBot.setHtmlWithSelection("<h1 class=\"autonumber\">^Heading</h1>");
+      this.editorBot.setHtmlWithSelection("<h1 class=\"autonumber autonumber-0\">^Heading</h1>");
       this.editorBot.execCommand("setCurrentStyle", "Letter Lowercase Roman");
       this.editorBot.execCommand("reapplyStyle");
       var updatedContent = bender.tools.getHtmlWithSelection(this.editorBot.editor);
 
       assert.areSame(
-        "<h1 class=\"autonumber autonumber-A\">^Heading</h1>", updatedContent,
+        "<h1 class=\"autonumber autonumber-0 autonumber-A\">^Heading</h1>", updatedContent,
         "Header Style Applied"
           );
     },


### PR DESCRIPTION
## #27 What It is
- List of numbered elements is now configurable
- Element numbering is based on it's position in the list (number does not start from h1, it starts from element 0)
- CSS updated with new classes to signify position in numbering list (autonumber-0, autonumber-1)

### Key Changes
`numberedElements` is now a configurable option. By default, this is an array that includes h1-h6. And thus, numbering starts at H1 and ends at H6. This array can be set during editor initialization for example as `["h2", "h3", "h4"]` This will cause numbering to be started from H2 elements, ending at H4. All new CSS classes and setup is in place to allow for this, which has a number of effects.

Previously if an H2 Element was numbered without an H1 before it, it would show as 0.1 instead of 1, because the styling was hard-coded to start from H1 in the CSS. Now, additional classes are defined to handle numbering based on the index of the element in the `numberedElements` array. So for example H2 is now at index 0, and so the numbering class autonumber-0 is applied, which is where counting starts. Numbering logically starts at whatever is the first element in the array.

Further, in this setup toggling the 'Match Heading' button while inside a header that is not part of the numbering scheme, will not set it to a Paragraph, but will first set it to the first allowed numbered element. In our example, an H1 element would become an H2, because H2 is the first allowed element. toggling the 'Match Heading' a second time would bring it back to a Paragraph.

Also, the 'Header increase / decrease' buttons are limited to the `numberedElements` array. In the current example you would be able to "decrease" the header as far as H4, and then the button will become disabled, because H4 is the deepest element in the array. In this case, H5 and H6 are unavailable to be used.