### PR TITLE
Keyboard shortcuts

### DIFF
--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -218,6 +218,22 @@
       }));
 
       CKEDITOR.dialog.add("selectStyle", this.path + "dialogs/selectstyle.js");
+      
+      // Indent and outdent with TAB/SHIFT+TAB key
+      editor.on( 'key', function( evt ) {
+          if ( editor.mode != 'wysiwyg' ) {
+              return;
+          }
+          
+          if ( evt.data.keyCode == 9 ) {
+              editor.execCommand( "increaseHeadingLevel" );
+              evt.cancel();
+          } else if ( evt.data.keyCode == CKEDITOR.SHIFT + 9 ) {
+              editor.execCommand( "decreaseHeadingLevel" );
+              evt.cancel();
+          }
+          
+      }, this );
 
     }
   });

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -218,7 +218,7 @@
       }));
 
       CKEDITOR.dialog.add("selectStyle", this.path + "dialogs/selectstyle.js");
-      
+
       // Indent and outdent with TAB/SHIFT+TAB key
       var tabKey = 9;
       editor.on("key", function (evt) {

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -195,6 +195,9 @@
          "selectStyle",
     hidpi: true,
     init: function (editor) {
+
+      var TAB_KEY_CODE = 9;
+
       editor.config.autonumberStyleImgPath = this.path + "dialogs/img";
       editor.addContentsCss(this.path + "styles/numbering.css");
 
@@ -220,15 +223,14 @@
       CKEDITOR.dialog.add("selectStyle", this.path + "dialogs/selectstyle.js");
 
       // Indent and outdent with TAB/SHIFT+TAB key
-      var tabKey = 9;
       editor.on("key", function (evt) {
         if (editor.mode !== "wysiwyg") {
           return;
         }
 
-        if (evt.data.keyCode === tabKey) {
+        if (evt.data.keyCode === TAB_KEY_CODE) {
           editor.execCommand("increaseHeadingLevel");
-        } else if (evt.data.keyCode === CKEDITOR.SHIFT + tabKey) {
+        } else if (evt.data.keyCode === CKEDITOR.SHIFT + TAB_KEY_CODE) {
           editor.execCommand("decreaseHeadingLevel");
         }
 

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -218,22 +218,24 @@
       }));
 
       CKEDITOR.dialog.add("selectStyle", this.path + "dialogs/selectstyle.js");
-      
+
       // Indent and outdent with TAB/SHIFT+TAB key
-      editor.on( 'key', function( evt ) {
-          if ( editor.mode != 'wysiwyg' ) {
-              return;
-          }
-          
-          if ( evt.data.keyCode == 9 ) {
-              editor.execCommand( "increaseHeadingLevel" );
-              evt.cancel();
-          } else if ( evt.data.keyCode == CKEDITOR.SHIFT + 9 ) {
-              editor.execCommand( "decreaseHeadingLevel" );
-              evt.cancel();
-          }
-          
-      }, this );
+      editor.on("key", function (evt) {
+        if (editor.mode !== "wysiwyg") {
+          return;
+        }
+
+        var tabKey = 9;
+
+        if (evt.data.keyCode === tabKey) {
+          editor.execCommand("increaseHeadingLevel");
+        } else if (evt.data.keyCode === CKEDITOR.SHIFT + tabKey) {
+          editor.execCommand("decreaseHeadingLevel");
+        }
+
+        evt.cancel();
+
+      }, this, null, 1);
 
     }
   });

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -218,14 +218,13 @@
       }));
 
       CKEDITOR.dialog.add("selectStyle", this.path + "dialogs/selectstyle.js");
-
+      
       // Indent and outdent with TAB/SHIFT+TAB key
+      var tabKey = 9;
       editor.on("key", function (evt) {
         if (editor.mode !== "wysiwyg") {
           return;
         }
-
-        var tabKey = 9;
 
         if (evt.data.keyCode === tabKey) {
           editor.execCommand("increaseHeadingLevel");

--- a/tests/structuredheadings/keyboardshortcuts.js
+++ b/tests/structuredheadings/keyboardshortcuts.js
@@ -1,0 +1,39 @@
+/* bender-tags: editor,unit */
+/* bender-ckeditor-plugins: wysiwygarea,structuredheadings,toolbar,basicstyles,dialog */
+
+// Clean up all instances been created on the page.
+(function () {
+
+  bender.editor = {
+    allowedForTests: "h1; h2; h3"
+  };
+
+  bender.test({
+    setUp: function () {
+      //Anything to be run before each test if needed
+    },
+
+    "H2 to H3 from Tab": function () {
+      this.editorBot.setHtmlWithSelection("<h2>^Heading</h2>");
+      this.editor.fire('key', { keyCode: 9 });
+      var updatedContent = bender.tools.getHtmlWithSelection(this.editorBot.editor);
+      
+      assert.areSame(
+        "<h3>^Heading</h3>", updatedContent,
+        "Header increased from TAB"
+      );
+    },
+    
+    "H2 to H1 from Shift-Tab": function () {
+        this.editorBot.setHtmlWithSelection("<h2>^Heading</h2>");
+        this.editor.fire('key', { keyCode: CKEDITOR.SHIFT + 9 });
+        var updatedContent = bender.tools.getHtmlWithSelection(this.editorBot.editor);
+        
+        assert.areSame(
+          "<h1>^Heading</h1>", updatedContent,
+          "Header increased from Shift-TAB"
+        );
+      }
+    
+  });
+})();

--- a/tests/structuredheadings/keyboardshortcuts.js
+++ b/tests/structuredheadings/keyboardshortcuts.js
@@ -4,6 +4,8 @@
 // Clean up all instances been created on the page.
 (function () {
 
+  var tabKey = 9;
+
   bender.editor = {
     allowedForTests: "h1; h2; h3"
   };
@@ -15,7 +17,6 @@
 
     "H2 to H3 from Tab": function () {
       this.editorBot.setHtmlWithSelection("<h2>^Heading</h2>");
-      var tabKey = 9;
       this.editor.fire("key", { keyCode: tabKey });
       var updatedContent = bender.tools.getHtmlWithSelection(this.editorBot.editor);
 
@@ -27,13 +28,12 @@
 
     "H2 to H1 from Shift-Tab": function () {
       this.editorBot.setHtmlWithSelection("<h2>^Heading</h2>");
-      var tabKey = 9;
       this.editor.fire("key", { keyCode: CKEDITOR.SHIFT + tabKey });
       var updatedContent = bender.tools.getHtmlWithSelection(this.editorBot.editor);
 
       assert.areSame(
           "<h1>^Heading</h1>", updatedContent,
-          "Header increased from Shift-TAB"
+          "Header decreased from Shift-TAB"
         );
     }
 

--- a/tests/structuredheadings/keyboardshortcuts.js
+++ b/tests/structuredheadings/keyboardshortcuts.js
@@ -15,25 +15,27 @@
 
     "H2 to H3 from Tab": function () {
       this.editorBot.setHtmlWithSelection("<h2>^Heading</h2>");
-      this.editor.fire('key', { keyCode: 9 });
+      var tabKey = 9;
+      this.editor.fire("key", { keyCode: tabKey });
       var updatedContent = bender.tools.getHtmlWithSelection(this.editorBot.editor);
-      
+
       assert.areSame(
         "<h3>^Heading</h3>", updatedContent,
         "Header increased from TAB"
       );
     },
-    
+
     "H2 to H1 from Shift-Tab": function () {
-        this.editorBot.setHtmlWithSelection("<h2>^Heading</h2>");
-        this.editor.fire('key', { keyCode: CKEDITOR.SHIFT + 9 });
-        var updatedContent = bender.tools.getHtmlWithSelection(this.editorBot.editor);
-        
-        assert.areSame(
+      this.editorBot.setHtmlWithSelection("<h2>^Heading</h2>");
+      var tabKey = 9;
+      this.editor.fire("key", { keyCode: CKEDITOR.SHIFT + tabKey });
+      var updatedContent = bender.tools.getHtmlWithSelection(this.editorBot.editor);
+
+      assert.areSame(
           "<h1>^Heading</h1>", updatedContent,
           "Header increased from Shift-TAB"
         );
-      }
-    
+    }
+
   });
 })();


### PR DESCRIPTION
# #29 Keyboard Shortcuts

- [x] Tab applies 'Increase Header Level"
- [x] Shift+Tab applies "Decrease Header Level"
- [x] When outside a header, and in a list, normal indent/outdent functionality is untouched
- [x] When in a header that is a list item, Header functions take priority and list indent/outdent no longer work