### PR TITLE
Heading level changes not restricted when not numbered

### DIFF
--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -143,7 +143,7 @@
         "autonumber-2",
         "autonumber-3",
         "autonumber-4",
-        "autonumbe4-5"
+        "autonumber-5"
       ],
       "Number Lowercase Roman": [
         "autonumber-N",
@@ -180,6 +180,25 @@
       };
 
     editor.config.autonumberCurrentStyle = "Numeric"; //hold current style or null if default
+  };
+
+  var elementStyles = {
+      //eslint-disable-next-line new-cap
+    div: new CKEDITOR.style({ element: "div" }),
+      //eslint-disable-next-line new-cap
+    p: new CKEDITOR.style({ element: "p" }),
+      //eslint-disable-next-line new-cap
+    h1: new CKEDITOR.style({ element: "h1" }),
+      //eslint-disable-next-line new-cap
+    h2: new CKEDITOR.style({ element: "h2" }),
+      //eslint-disable-next-line new-cap
+    h3: new CKEDITOR.style({ element: "h3" }),
+      //eslint-disable-next-line new-cap
+    h4: new CKEDITOR.style({ element: "h4" }),
+      //eslint-disable-next-line new-cap
+    h5: new CKEDITOR.style({ element: "h5" }),
+      //eslint-disable-next-line new-cap
+    h6: new CKEDITOR.style({ element: "h6" })
   };
 
 /*
@@ -257,6 +276,19 @@
         exec: function (editor) {
           var element = editor.elementPath().block;
 
+        //set to maximum level of the previous level + 1
+          var previousHeader = getPreviousHeader(editor, element);
+
+          if (previousHeader && isNumbered(editor, previousHeader)) {
+            var maxElement = editor.config.numberedElements[editor.config.numberedElements.indexOf(
+              previousHeader.getName()) + 1];
+            if (editor.config.numberedElements.indexOf(element.getName()) >
+              editor.config.numberedElements.indexOf(maxElement)) {
+              editor.applyStyle(elementStyles[maxElement]);
+              element = editor.elementPath().block;
+            }
+          }
+
           if (!isNumbered(editor, element)) {
             element.addClass(editor.config.autonumberBaseClass);
             setStyle(editor, element, editor.config.autonumberCurrentStyle);
@@ -288,24 +320,6 @@
         contextSensitive: 1,
         startDisabled: true,
         exec: function (editor) {
-          var elementStyles = {
-            //eslint-disable-next-line new-cap
-            div: new CKEDITOR.style({ element: "div" }),
-            //eslint-disable-next-line new-cap
-            p: new CKEDITOR.style({ element: "p" }),
-            //eslint-disable-next-line new-cap
-            h1: new CKEDITOR.style({ element: "h1" }),
-            //eslint-disable-next-line new-cap
-            h2: new CKEDITOR.style({ element: "h2" }),
-            //eslint-disable-next-line new-cap
-            h3: new CKEDITOR.style({ element: "h3" }),
-            //eslint-disable-next-line new-cap
-            h4: new CKEDITOR.style({ element: "h4" }),
-            //eslint-disable-next-line new-cap
-            h5: new CKEDITOR.style({ element: "h5" }),
-            //eslint-disable-next-line new-cap
-            h6: new CKEDITOR.style({ element: "h6" })
-          };
           var previousHeader = getPreviousHeader(editor, editor.elementPath().block);
 
         // if already in header, set back to default based on enter mode
@@ -357,18 +371,6 @@
           var nextElement = editor.config.numberedElements[editor.config.numberedElements.indexOf(
             element.getName()) + 1];
 
-        //set a maximum level of the previous level + 1
-          var previousHeader = getPreviousHeader(editor, element);
-
-          if (previousHeader) {
-            var maxElement = editor.config.numberedElements[editor.config.numberedElements.indexOf(
-              previousHeader.getName()) + 1];
-            if (editor.config.numberedElements.indexOf(nextElement) >
-              editor.config.numberedElements.indexOf(maxElement)) {
-              nextElement = maxElement;
-            }
-          }
-
         //eslint-disable-next-line new-cap
           var style = new CKEDITOR.style({ element: nextElement});
           editor.applyStyle(style);
@@ -384,9 +386,12 @@
               editor.config.numberedElements.indexOf(path.block.getName())) {
               this.setState(CKEDITOR.TRISTATE_DISABLED);
             } else if (
-            previousHeader && path.block.getName() ===
-            editor.config.numberedElements[editor.config.numberedElements.indexOf(
-              previousHeader.getName()) + 1]
+            previousHeader &&
+            isNumbered(editor, previousHeader) &&
+            isNumbered(editor, path.block) &&
+            editor.config.numberedElements.indexOf(path.block.getName()) >
+            editor.config.numberedElements.indexOf(previousHeader.getName())
+
           ) {
               this.setState(CKEDITOR.TRISTATE_DISABLED);
             } else {

--- a/tests/structuredheadings/autonumber.js
+++ b/tests/structuredheadings/autonumber.js
@@ -77,7 +77,7 @@
     },
 
     "AutoNumber Removes Class, Sets State Off": function () {
-      this.editorBot.setHtmlWithSelection("<h1 class='autonumber'>^Heading</h1>");
+      this.editorBot.setHtmlWithSelection("<h1 class=\"autonumber\">^Heading</h1>");
       var testCommand = this.editor.getCommand("autoNumberHeading");
       this.editorBot.execCommand("autoNumberHeading");
       var updatedContent = bender.tools.getHtmlWithSelection(this.editorBot.editor);
@@ -89,6 +89,24 @@
       assert.areSame(
             CKEDITOR.TRISTATE_OFF, testCommand.state,
             "autoNumberHeading OFF"
+          );
+    },
+
+    "AutoNumber Forces Header Level Restriction": function () {
+      this.editorBot.setHtmlWithSelection("<h1 class=\"autonumber autonumber-0\">Heading</h1>" +
+                "<h3>^Heading</h3>");
+      var testCommand = this.editor.getCommand("autoNumberHeading");
+      this.editorBot.execCommand("autoNumberHeading");
+      var updatedContent = bender.tools.getHtmlWithSelection(this.editorBot.editor);
+
+      assert.areSame(
+        "<h1 class=\"autonumber autonumber-0\">Heading</h1>" +
+        "<h2 class=\"autonumber autonumber-1\">^Heading</h2>", updatedContent,
+        "Header Restricted when Numbered"
+          );
+      assert.areSame(
+        CKEDITOR.TRISTATE_ON, testCommand.state,
+        "autoNumberHeading ON"
           );
     }
 

--- a/tests/structuredheadings/changelevel.js
+++ b/tests/structuredheadings/changelevel.js
@@ -133,12 +133,13 @@
     },
 
     "Increase disabled if already at Previous + 1": function () {
-      this.editorBot.setHtmlWithSelection("<h1>Previous</h1><h2>^Heading</h2>");
+      this.editorBot.setHtmlWithSelection("<h1 class='autonumber'>Previous</h1>" +
+              "<h2 class='autonumber'>^Heading</h2>");
       var testCommand = this.editor.getCommand("increaseHeadingLevel");
 
       assert.areSame(
             CKEDITOR.TRISTATE_DISABLED, testCommand.state,
-            "increaseHeaderLevel DISABLED in previous +1"
+            "increaseHeaderLevel DISABLED in numbered previous +1"
           );
     }
 


### PR DESCRIPTION
# #25 Skipping Header Levels
- When in a non-numbered header, no restrictions on heading level changes
- When in a numbered header, but the previous header is not numbered, no restrictions
- When in a numbered header with a previous numbered header, THEN restricted to +1 level
- When in a non-numbered header with a previous header, changing beyond restriction and then enabling numbering, the header is pulled back to previous + 1 to enforce the restrction
