### PR TITLE
fix #38 - correct the autonumbering state when creating new headings

### DIFF
--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -218,7 +218,7 @@
         onClick: function (value) {
           var previousHeader = getPreviousHeader(editor, editor.elementPath().block);
           editor.applyStyle(elementStyles[ value ]);
-          if (isNumbered(editor, previousHeader)) {
+          if (previousHeader && isNumbered(editor, previousHeader)) {
             setNumbering(editor, editor.elementPath().block);
             setLevel(editor, editor.elementPath().block);
             editor.execCommand("reapplyStyle");

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -169,6 +169,14 @@
     editor.config.autonumberCurrentStyle || "1.1.1.1.1.";
   };
 
+    var overrideFormattingOnClick = function (editor) {
+      var oldOnClick = editor.ui.get("Format").onClick;
+      editor.ui.get("Format").onClick = function (value) {
+        oldOnClick(value);
+        console.log("this is the overidden one");
+      };
+    };
+
 /*
  * Structured Headings Plugin Setup
  */
@@ -351,6 +359,8 @@
         }
 
       }, this, null, 1);
+
+      overrideFormattingOnClick(editor);
 
     }
   });

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -352,8 +352,6 @@
 
       }, this, null, 1);
 
-      overrideFormattingOnClick(editor);
-
     }
   });
 

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -169,14 +169,6 @@
     editor.config.autonumberCurrentStyle || "1.1.1.1.1.";
   };
 
-    var overrideFormattingOnClick = function (editor) {
-      var oldOnClick = editor.ui.get("Format").onClick;
-      editor.ui.get("Format").onClick = function (value) {
-        oldOnClick(value);
-        console.log("this is the overidden one");
-      };
-    };
-
 /*
  * Structured Headings Plugin Setup
  */

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -218,7 +218,7 @@
         onClick: function (value) {
           var previousHeader = getPreviousHeader(editor, editor.elementPath().block);
           editor.applyStyle(elementStyles[ value ]);
-          if (previousHeader && isNumbered(editor, previousHeader)) {
+          if (!previousHeader || isNumbered(editor, previousHeader)) {
             setNumbering(editor, editor.elementPath().block);
             setLevel(editor, editor.elementPath().block);
             editor.execCommand("reapplyStyle");

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -216,18 +216,21 @@
         },
 
         onClick: function (value) {
-          var previousHeader = getPreviousHeader(editor, editor.elementPath().block);
           editor.applyStyle(elementStyles[ value ]);
-          if (!previousHeader || isNumbered(editor, previousHeader)) {
-            setNumbering(editor, editor.elementPath().block);
-            setLevel(editor, editor.elementPath().block);
-            editor.execCommand("reapplyStyle");
-          }
+          var block = editor.elementPath().block;
+          var previousHeader = getPreviousHeader(editor, block);
           if (value === "p") {
+            CKEDITOR.plugins.structuredheadings.clearAll(editor, block);
             this.setValue(value, "Normal Text");
           } else if (value === "pre") {
+            CKEDITOR.plugins.structuredheadings.clearAll(editor, block);
             this.setValue(value, "Formatted Text");
           } else {
+            if (!previousHeader || isNumbered(editor, previousHeader)) {
+              setNumbering(editor, block);
+              setLevel(editor, block);
+              editor.execCommand("reapplyStyle");
+            }
             this.setValue(
                 value,
                 "Header " + editor.config.numberedElements[
@@ -364,6 +367,14 @@
  */
 
   CKEDITOR.plugins.structuredheadings = {
+    clearAll: function (editor, element) {
+      clearLevel(editor, element);
+      clearNumbering(editor, element);
+      clearStyles(editor, element);
+    },
+    getCurrentBlockFromPath: function (editor) {
+      return editor.elementPath().block;
+    },
     commands: {
     /*
      * matchHeading

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -216,10 +216,13 @@
         },
 
         onClick: function (value) {
+          var previousHeader = getPreviousHeader(editor, editor.elementPath().block);
           editor.applyStyle(elementStyles[ value ]);
-          setNumbering(editor, editor.elementPath().block);
-          setLevel(editor, editor.elementPath().block);
-          editor.execCommand("reapplyStyle");
+          if (isNumbered(editor, previousHeader)) {
+            setNumbering(editor, editor.elementPath().block);
+            setLevel(editor, editor.elementPath().block);
+            editor.execCommand("reapplyStyle");
+          }
           if (value === "p") {
             this.setValue(value, "Normal Text");
           } else if (value === "pre") {

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -217,6 +217,7 @@
 
         onClick: function (value) {
           editor.applyStyle(elementStyles[ value ]);
+          setNumbering(editor, editor.elementPath().block);
           setLevel(editor, editor.elementPath().block);
           editor.execCommand("reapplyStyle");
           if (value === "p") {

--- a/tests/structuredheadings/formatcombo.js
+++ b/tests/structuredheadings/formatcombo.js
@@ -1,0 +1,32 @@
+/* bender-tags: editor,unit */
+/* bender-ckeditor-plugins: wysiwygarea,structuredheadings,toolbar,basicstyles,dialog,richcombo */
+
+// Clean up all instances been created on the page.
+(function () {
+
+  bender.editor = {
+    allowedForTests: "h1; h2; p"
+  };
+
+  bender.test({
+    setUp: function () {
+      //Anything to be run before each test if needed
+    },
+
+    "test apply format style": function () {
+      var bot = this.editorBot;
+      var ed = this.editor;
+      bot.setHtmlWithSelection("<p>^foo</p>");
+      var name = "NumFormats";
+      var formatCombo = ed.ui.get(name);
+      assert.areSame(CKEDITOR.TRISTATE_OFF, formatCombo._.state, "check state OFF");
+
+      bot.combo(name, function (combo) {
+        assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
+        combo.onClick("h2");
+        assert.areSame("<h2>^foo</h2>", bot.htmlWithSelection(), "applied h1 block style");
+      });
+    }
+
+  });
+})();

--- a/tests/structuredheadings/formatcombo.js
+++ b/tests/structuredheadings/formatcombo.js
@@ -4,6 +4,8 @@
 // Clean up all instances been created on the page.
 (function () {
 
+  var comboName = "NumFormats";
+
   bender.editor = {
     allowedForTests: "h1; h2; p"
   };
@@ -17,13 +19,14 @@
       var bot = this.editorBot;
       var ed = this.editor;
       bot.setHtmlWithSelection("<p>^foo</p>");
-      var name = "NumFormats";
-      var formatCombo = ed.ui.get(name);
+      var formatCombo = ed.ui.get(comboName);
       assert.areSame(CKEDITOR.TRISTATE_OFF, formatCombo._.state, "check state OFF");
 
-      bot.combo(name, function (combo) {
+      bot.combo(comboName, function (combo) {
         assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
+        // click h2
         combo.onClick("h2");
+        // the new h2 has autonumbering set, since no prior heading exists
         assert.areSame(
             "<h2 class=\"autonumber autonumber-1\">^foo</h2>",
             bot.htmlWithSelection(),
@@ -35,16 +38,17 @@
     "if previous heading is autonumber, the new heading is autonumbered": function () {
       var bot = this.editorBot;
       var ed = this.editor;
-      bot.setHtmlWithSelection("<h2 class=\"autonumber autonumber-0\">bar</h2><p>^foo</p>");
-      var name = "NumFormats";
-      var formatCombo = ed.ui.get(name);
+      bot.setHtmlWithSelection("<h1 class=\"autonumber autonumber-0\">bar</h1><p>^foo</p>");
+      var formatCombo = ed.ui.get(comboName);
       assert.areSame(CKEDITOR.TRISTATE_OFF, formatCombo._.state, "check state OFF");
 
-      bot.combo(name, function (combo) {
+      bot.combo(comboName, function (combo) {
         assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
+        // click h2
         combo.onClick("h2");
+        // the new h2 has autonumbering set, at the next level from h1
         assert.areSame(
-            "<h2 class=\"autonumber autonumber-0\">bar</h2>" +
+            "<h1 class=\"autonumber autonumber-0\">bar</h1>" +
             "<h2 class=\"autonumber autonumber-1\">^foo</h2>",
             bot.htmlWithSelection(),
             "applied h2 block autonumber style"
@@ -57,13 +61,15 @@
       var bot = this.editorBot;
       var ed = this.editor;
       bot.setHtmlWithSelection("<h2>bar</h2><p>^foo</p>");
-      var name = "NumFormats";
-      var formatCombo = ed.ui.get(name);
+      var formatCombo = ed.ui.get(comboName);
+
       assert.areSame(CKEDITOR.TRISTATE_OFF, formatCombo._.state, "check state OFF");
 
-      bot.combo(name, function (combo) {
+      bot.combo(comboName, function (combo) {
         assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
+        // click h2
         combo.onClick("h2");
+        // the new heading doesn't have autonumbering, since the prior heading did not
         assert.areSame(
             "<h2>bar</h2><h2>^foo</h2>",
             bot.htmlWithSelection(),

--- a/tests/structuredheadings/formatcombo.js
+++ b/tests/structuredheadings/formatcombo.js
@@ -25,7 +25,7 @@
         assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
         combo.onClick("h2");
         assert.areSame(
-            "<h2 class=\"autonumber-1\">^foo</h2>",
+            "<h2 class=\"autonumber autonumber-1\">^foo</h2>",
             bot.htmlWithSelection(),
             "applied h1 block style"
         );

--- a/tests/structuredheadings/formatcombo.js
+++ b/tests/structuredheadings/formatcombo.js
@@ -44,7 +44,8 @@
         assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
         combo.onClick("h2");
         assert.areSame(
-            "<h2 class=\"autonumber autonumber-0\">bar</h2><h2 class=\"autonumber autonumber-1\">^foo</h2>",
+            "<h2 class=\"autonumber autonumber-0\">bar</h2>" +
+            "<h2 class=\"autonumber autonumber-1\">^foo</h2>",
             bot.htmlWithSelection(),
             "applied h2 block autonumber style"
         );
@@ -69,7 +70,7 @@
             "applied h2 block non-autonumbered style"
         );
       });
-    },
+    }
 
   });
 })();

--- a/tests/structuredheadings/formatcombo.js
+++ b/tests/structuredheadings/formatcombo.js
@@ -76,6 +76,44 @@
             "applied h2 block non-autonumbered style"
         );
       });
+    },
+
+    "p option no-ops": function () {
+      var bot = this.editorBot;
+      var ed = this.editor;
+      bot.setHtmlWithSelection("<p>^foo</p>");
+      var formatCombo = ed.ui.get(comboName);
+      assert.areSame(CKEDITOR.TRISTATE_OFF, formatCombo._.state, "check state OFF");
+
+      bot.combo(comboName, function (combo) {
+        assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
+        // click p
+        combo.onClick("p");
+        assert.areSame(
+            "<p>^foo</p>",
+            bot.htmlWithSelection(),
+            "applied p to p"
+        );
+      });
+    },
+
+    "p on autonumbered heading removes classes": function () {
+      var bot = this.editorBot;
+      var ed = this.editor;
+      bot.setHtmlWithSelection("<h1 class=\"autonumber autonumber-0\">^foo</h1>");
+      var formatCombo = ed.ui.get(comboName);
+      assert.areSame(CKEDITOR.TRISTATE_OFF, formatCombo._.state, "check state OFF");
+
+      bot.combo(comboName, function (combo) {
+        assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
+        // click p
+        combo.onClick("p");
+        assert.areSame(
+            "<p>^foo</p>",
+            bot.htmlWithSelection(),
+            "applied p to h1"
+        );
+      });
     }
 
   });

--- a/tests/structuredheadings/formatcombo.js
+++ b/tests/structuredheadings/formatcombo.js
@@ -24,7 +24,11 @@
       bot.combo(name, function (combo) {
         assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
         combo.onClick("h2");
-        assert.areSame("<h2>^foo</h2>", bot.htmlWithSelection(), "applied h1 block style");
+        assert.areSame(
+            "<h2 class=\"autonumber-1\">^foo</h2>",
+            bot.htmlWithSelection(),
+            "applied h1 block style"
+        );
       });
     }
 

--- a/tests/structuredheadings/formatcombo.js
+++ b/tests/structuredheadings/formatcombo.js
@@ -35,7 +35,7 @@
     "if previous heading is autonumber, the new heading is autonumbered": function () {
       var bot = this.editorBot;
       var ed = this.editor;
-      bot.setHtmlWithSelection("<h2 class=\"autonumber autonumber-1\">bar</h2><p>^foo</p>");
+      bot.setHtmlWithSelection("<h2 class=\"autonumber autonumber-0\">bar</h2><p>^foo</p>");
       var name = "NumFormats";
       var formatCombo = ed.ui.get(name);
       assert.areSame(CKEDITOR.TRISTATE_OFF, formatCombo._.state, "check state OFF");
@@ -44,7 +44,7 @@
         assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
         combo.onClick("h2");
         assert.areSame(
-            "<h2 class=\"autonumber autonumber-1\">bar</h2><h2 class=\"autonumber autonumber-1\">^foo</h2>",
+            "<h2 class=\"autonumber autonumber-0\">bar</h2><h2 class=\"autonumber autonumber-1\">^foo</h2>",
             bot.htmlWithSelection(),
             "applied h2 block autonumber style"
         );

--- a/tests/structuredheadings/formatcombo.js
+++ b/tests/structuredheadings/formatcombo.js
@@ -114,6 +114,43 @@
             "applied p to h1"
         );
       });
+    },
+    "pre option on a p": function () {
+      var bot = this.editorBot;
+      var ed = this.editor;
+      bot.setHtmlWithSelection("<p>^foo</p>");
+      var formatCombo = ed.ui.get(comboName);
+      assert.areSame(CKEDITOR.TRISTATE_OFF, formatCombo._.state, "check state OFF");
+
+      bot.combo(comboName, function (combo) {
+        assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
+        // click pre
+        combo.onClick("pre");
+        assert.areSame(
+            "<pre>^foo</pre>",
+            bot.htmlWithSelection(),
+            "applied pre to p"
+        );
+      });
+    },
+
+    "pre on autonumbered heading removes autonumbering classes": function () {
+      var bot = this.editorBot;
+      var ed = this.editor;
+      bot.setHtmlWithSelection("<h1 class=\"autonumber autonumber-0\">^foo</h1>");
+      var formatCombo = ed.ui.get(comboName);
+      assert.areSame(CKEDITOR.TRISTATE_OFF, formatCombo._.state, "check state OFF");
+
+      bot.combo(comboName, function (combo) {
+        assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
+        // click pre
+        combo.onClick("pre");
+        assert.areSame(
+            "<pre>^foo</pre>",
+            bot.htmlWithSelection(),
+            "applied pre to h1"
+        );
+      });
     }
 
   });

--- a/tests/structuredheadings/formatcombo.js
+++ b/tests/structuredheadings/formatcombo.js
@@ -13,7 +13,7 @@
       //Anything to be run before each test if needed
     },
 
-    "test apply format style": function () {
+    "if no headings in document, the new heading is autonumbered": function () {
       var bot = this.editorBot;
       var ed = this.editor;
       bot.setHtmlWithSelection("<p>^foo</p>");
@@ -27,10 +27,49 @@
         assert.areSame(
             "<h2 class=\"autonumber autonumber-1\">^foo</h2>",
             bot.htmlWithSelection(),
-            "applied h1 block style"
+            "applied h2 block autonumberstyle"
         );
       });
-    }
+    },
+
+    "if previous heading is autonumber, the new heading is autonumbered": function () {
+      var bot = this.editorBot;
+      var ed = this.editor;
+      bot.setHtmlWithSelection("<h2 class=\"autonumber autonumber-1\">bar</h2><p>^foo</p>");
+      var name = "NumFormats";
+      var formatCombo = ed.ui.get(name);
+      assert.areSame(CKEDITOR.TRISTATE_OFF, formatCombo._.state, "check state OFF");
+
+      bot.combo(name, function (combo) {
+        assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
+        combo.onClick("h2");
+        assert.areSame(
+            "<h2 class=\"autonumber autonumber-1\">bar</h2><h2 class=\"autonumber autonumber-1\">^foo</h2>",
+            bot.htmlWithSelection(),
+            "applied h2 block autonumber style"
+        );
+      });
+    },
+
+
+    "if previous heading is not autonumber, the new heading is not autonumbered": function () {
+      var bot = this.editorBot;
+      var ed = this.editor;
+      bot.setHtmlWithSelection("<h2>bar</h2><p>^foo</p>");
+      var name = "NumFormats";
+      var formatCombo = ed.ui.get(name);
+      assert.areSame(CKEDITOR.TRISTATE_OFF, formatCombo._.state, "check state OFF");
+
+      bot.combo(name, function (combo) {
+        assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
+        combo.onClick("h2");
+        assert.areSame(
+            "<h2>bar</h2><h2>^foo</h2>",
+            bot.htmlWithSelection(),
+            "applied h2 block non-autonumbered style"
+        );
+      });
+    },
 
   });
 })();


### PR DESCRIPTION
When changing a paragraph to a heading (h1-h6):

If there is no previous heading, or if the previous heading is structured, make sure the new heading has the structured heading classes.

Otherwise, do not append any structured heading related css classes 