### PR TITLE
Fix multi-select (issue #41)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "bender run -l && bender run",
+    "test": "bender run -l && bender run -b firefox",
     "lint": "eslint --format compact .",
     "fix-lint": "eslint --fix --format compact .",
     "symlink-plugin-to-ckeditor": "ln -s ../../structuredheadings ckeditor/plugins/structuredheadings"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "bender run",
+    "test": "bender run -l && bender run",
     "lint": "eslint --format compact .",
     "fix-lint": "eslint --fix --format compact .",
     "symlink-plugin-to-ckeditor": "ln -s ../../structuredheadings ckeditor/plugins/structuredheadings"

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -478,6 +478,8 @@
 
       /*
        * reapplyStyle
+       * Finds all autonumbered headings,
+       * and applies the selected numbering style.
        */
       reapplyStyle: {
         exec: function (editor, style) {

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -302,17 +302,31 @@
             clearLevel(editor, editor.elementPath().block);
             clearNumbering(editor, editor.elementPath().block);
           } else {
-            var headings = CKEDITOR.plugins.structuredheadings.getHeadingsInSelection(editor, editor.getSelection());
-            if (headings.length > 0) {
-              for (var i = 0; i < headings.length; i++) {
-                setNumbering(editor, headings[i]);
-                setLevel(editor, headings[i]);
-                setCurrentStyle(editor, headings[i], value);
+            var selection = editor.getSelection();
+            if (selection.getRanges()[0].collapsed) {
+              this.setStyleForHeading(
+                CKEDITOR.plugins.structuredheadings.getCurrentBlockFromPath(editor)
+              );
+            } else {
+              var headings = CKEDITOR.plugins.structuredheadings.getHeadingsInSelection(
+                editor,
+                selection
+              );
+              if (headings.length > 0) {
+                for (var i = 0; i < headings.length; i++) {
+                  this.setStyleForHeading(headings[i]);
+                }
               }
-              editor.execCommand("reapplyStyle", value);
-              this.setValue(value, value);
             }
+            editor.execCommand("reapplyStyle", value);
+            this.setValue(value, value);
           }
+        },
+
+        setStyleForHeading: function (heading, value) {
+          setNumbering(editor, heading);
+          setLevel(editor, heading);
+          setCurrentStyle(editor, heading, value);
         },
 
         onRender: function () {

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -375,7 +375,7 @@
     getHeadingsInSelection: function (editor, selection) {
       // forget Firefox multirange for now
       var range = selection.getRanges()[0];
-      var walker = new CKEDITOR.dom.walker(range);
+      var walker = new CKEDITOR.dom.walker(range); // eslint-disable-line new-cap
       walker.evaluator = function (node) {
         if (node.type !== CKEDITOR.NODE_ELEMENT) {
           return false;

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -303,6 +303,7 @@
             clearNumbering(editor, editor.elementPath().block);
           } else {
             var headings = CKEDITOR.plugins.structuredheadings.getHeadingsInSelection(editor, editor.getSelection());
+            console.log(headings);
             setNumbering(editor, editor.elementPath().block);
             setLevel(editor, editor.elementPath().block);
             setCurrentStyle(editor, editor.elementPath().block, value);
@@ -371,8 +372,25 @@
     getHeadingsInSelection: function (editor, selection) {
       // forget Firefox multirange for now
       var range = selection.getRanges()[0];
-      range.enlarge(CKEDITOR.ENLARGE_ELEMENT);
-      var headings = range._find.apply(range, editor.config.numberedElements);
+      var walker = new CKEDITOR.dom.walker(range);
+      walker.evaluation = function (node) {
+        if (node.type !== CKEDITOR.NODE_ELEMENT) {
+          return false;
+        }
+
+        if (editor.config.numberedElements.indexOf(node.getName())) {
+          return true;
+        }
+        return false;
+      };
+
+      var headings = [];
+      var current = walker.next();
+
+      while (current) {
+        headings.push(current);
+        current = walker.next();
+      }
 
       return headings;
     },

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -299,6 +299,7 @@
             clearLevel(editor, editor.elementPath().block);
             clearNumbering(editor, editor.elementPath().block);
           } else {
+            var headings = CKEDITOR.plugins.structuredheadings.getHeadingsInSelection(editor, editor.getSelection());
             setNumbering(editor, editor.elementPath().block);
             setLevel(editor, editor.elementPath().block);
             setCurrentStyle(editor, editor.elementPath().block, value);
@@ -364,6 +365,15 @@
  */
 
   CKEDITOR.plugins.structuredheadings = {
+    getHeadingsInSelection: function (editor, selection) {
+      // forget Firefox multirange for now
+      var range = selection.getRanges()[0];
+      range.enlarge(CKEDITOR.ENLARGE_ELEMENT);
+      var headings = range._find.apply(range, editor.config.numberedElements);
+
+      return headings;
+
+    },
     commands: {
     /*
      * matchHeading

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -303,9 +303,10 @@
             clearLevel(editor, block);
             clearNumbering(editor, block);
           } else {
+            // convert any non-numbered headings to numbered
             var selection = editor.getSelection();
             if (selection.getRanges()[0].collapsed) {
-              this.setStyleForHeading(block);
+              this.setAutonumberClassesForHeading(block);
             } else {
               var headings = CKEDITOR.plugins.structuredheadings.getHeadingsInSelection(
                 editor,
@@ -313,16 +314,18 @@
               );
               if (headings.length > 0) {
                 for (var i = 0; i < headings.length; i++) {
-                  this.setStyleForHeading(headings[i]);
+                  this.setAutonumberClassesForHeading(headings[i]);
                 }
               }
             }
+            // apply the correct bulletstyle for all numbered headings
             editor.execCommand("reapplyStyle", value);
+            // set the combo box value
             this.setValue(value, value);
           }
         },
 
-        setStyleForHeading: function (heading, value) {
+        setAutonumberClassesForHeading: function (heading, value) {
           setNumbering(editor, heading);
           setLevel(editor, heading);
           setCurrentStyle(editor, heading, value);

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -303,10 +303,11 @@
             clearNumbering(editor, editor.elementPath().block);
           } else {
             var headings = CKEDITOR.plugins.structuredheadings.getHeadingsInSelection(editor, editor.getSelection());
-            console.log(headings);
-            setNumbering(editor, editor.elementPath().block);
-            setLevel(editor, editor.elementPath().block);
-            setCurrentStyle(editor, editor.elementPath().block, value);
+            for (var i = 0; i < headings.length; i++) {
+              setNumbering(editor, headings[i]);
+              setLevel(editor, headings[i]);
+              setCurrentStyle(editor, headings[i], value);
+            }
             editor.execCommand("reapplyStyle", value);
             this.setValue(value, value);
           }

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -306,7 +306,7 @@
             // convert any non-numbered headings to numbered
             var selection = editor.getSelection();
             if (selection.getRanges()[0].collapsed) {
-              this.setAutonumberClassesForHeading(block);
+              this.setAutonumberClassesForHeading(block, value);
             } else {
               var headings = CKEDITOR.plugins.structuredheadings.getHeadingsInSelection(
                 editor,
@@ -314,7 +314,7 @@
               );
               if (headings.length > 0) {
                 for (var i = 0; i < headings.length; i++) {
-                  this.setAutonumberClassesForHeading(headings[i]);
+                  this.setAutonumberClassesForHeading(headings[i], value);
                 }
               }
             }

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -373,12 +373,12 @@
       // forget Firefox multirange for now
       var range = selection.getRanges()[0];
       var walker = new CKEDITOR.dom.walker(range);
-      walker.evaluation = function (node) {
+      walker.evaluator = function (node) {
         if (node.type !== CKEDITOR.NODE_ELEMENT) {
           return false;
         }
 
-        if (editor.config.numberedElements.indexOf(node.getName())) {
+        if (editor.config.numberedElements.indexOf(node.getName()) !== -1) {
           return true;
         }
         return false;

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -295,18 +295,17 @@
         },
 
         onClick: function (value) {
+          var block = CKEDITOR.plugins.structuredheadings.getCurrentBlockFromPath(editor);
           if (value === "restart") {
             editor.execCommand("restartNumbering");
           } else if (value === "clear") {
-            clearStyles(editor, editor.elementPath().block);
-            clearLevel(editor, editor.elementPath().block);
-            clearNumbering(editor, editor.elementPath().block);
+            clearStyles(editor, block);
+            clearLevel(editor, block);
+            clearNumbering(editor, block);
           } else {
             var selection = editor.getSelection();
             if (selection.getRanges()[0].collapsed) {
-              this.setStyleForHeading(
-                CKEDITOR.plugins.structuredheadings.getCurrentBlockFromPath(editor)
-              );
+              this.setStyleForHeading(block);
             } else {
               var headings = CKEDITOR.plugins.structuredheadings.getHeadingsInSelection(
                 editor,

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -303,13 +303,15 @@
             clearNumbering(editor, editor.elementPath().block);
           } else {
             var headings = CKEDITOR.plugins.structuredheadings.getHeadingsInSelection(editor, editor.getSelection());
-            for (var i = 0; i < headings.length; i++) {
-              setNumbering(editor, headings[i]);
-              setLevel(editor, headings[i]);
-              setCurrentStyle(editor, headings[i], value);
+            if (headings.length > 0) {
+              for (var i = 0; i < headings.length; i++) {
+                setNumbering(editor, headings[i]);
+                setLevel(editor, headings[i]);
+                setCurrentStyle(editor, headings[i], value);
+              }
+              editor.execCommand("reapplyStyle", value);
+              this.setValue(value, value);
             }
-            editor.execCommand("reapplyStyle", value);
-            this.setValue(value, value);
           }
         },
 

--- a/tests/structuredheadings/formatcombo.js
+++ b/tests/structuredheadings/formatcombo.js
@@ -17,13 +17,9 @@
 
     "if no headings in document, the new heading is autonumbered": function () {
       var bot = this.editorBot;
-      var ed = this.editor;
       bot.setHtmlWithSelection("<p>^foo</p>");
-      var formatCombo = ed.ui.get(comboName);
-      assert.areSame(CKEDITOR.TRISTATE_OFF, formatCombo._.state, "check state OFF");
 
       bot.combo(comboName, function (combo) {
-        assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
         // click h2
         combo.onClick("h2");
         // the new h2 has autonumbering set, since no prior heading exists
@@ -37,13 +33,9 @@
 
     "if previous heading is autonumber, the new heading is autonumbered": function () {
       var bot = this.editorBot;
-      var ed = this.editor;
       bot.setHtmlWithSelection("<h1 class=\"autonumber autonumber-0\">bar</h1><p>^foo</p>");
-      var formatCombo = ed.ui.get(comboName);
-      assert.areSame(CKEDITOR.TRISTATE_OFF, formatCombo._.state, "check state OFF");
 
       bot.combo(comboName, function (combo) {
-        assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
         // click h2
         combo.onClick("h2");
         // the new h2 has autonumbering set, at the next level from h1
@@ -59,14 +51,9 @@
 
     "if previous heading is not autonumber, the new heading is not autonumbered": function () {
       var bot = this.editorBot;
-      var ed = this.editor;
       bot.setHtmlWithSelection("<h2>bar</h2><p>^foo</p>");
-      var formatCombo = ed.ui.get(comboName);
-
-      assert.areSame(CKEDITOR.TRISTATE_OFF, formatCombo._.state, "check state OFF");
 
       bot.combo(comboName, function (combo) {
-        assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
         // click h2
         combo.onClick("h2");
         // the new heading doesn't have autonumbering, since the prior heading did not
@@ -80,13 +67,9 @@
 
     "p option no-ops": function () {
       var bot = this.editorBot;
-      var ed = this.editor;
       bot.setHtmlWithSelection("<p>^foo</p>");
-      var formatCombo = ed.ui.get(comboName);
-      assert.areSame(CKEDITOR.TRISTATE_OFF, formatCombo._.state, "check state OFF");
 
       bot.combo(comboName, function (combo) {
-        assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
         // click p
         combo.onClick("p");
         assert.areSame(
@@ -99,13 +82,9 @@
 
     "p on autonumbered heading removes classes": function () {
       var bot = this.editorBot;
-      var ed = this.editor;
       bot.setHtmlWithSelection("<h1 class=\"autonumber autonumber-0\">^foo</h1>");
-      var formatCombo = ed.ui.get(comboName);
-      assert.areSame(CKEDITOR.TRISTATE_OFF, formatCombo._.state, "check state OFF");
 
       bot.combo(comboName, function (combo) {
-        assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
         // click p
         combo.onClick("p");
         assert.areSame(
@@ -117,13 +96,9 @@
     },
     "pre option on a p": function () {
       var bot = this.editorBot;
-      var ed = this.editor;
       bot.setHtmlWithSelection("<p>^foo</p>");
-      var formatCombo = ed.ui.get(comboName);
-      assert.areSame(CKEDITOR.TRISTATE_OFF, formatCombo._.state, "check state OFF");
 
       bot.combo(comboName, function (combo) {
-        assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
         // click pre
         combo.onClick("pre");
         assert.areSame(
@@ -136,13 +111,9 @@
 
     "pre on autonumbered heading removes autonumbering classes": function () {
       var bot = this.editorBot;
-      var ed = this.editor;
       bot.setHtmlWithSelection("<h1 class=\"autonumber autonumber-0\">^foo</h1>");
-      var formatCombo = ed.ui.get(comboName);
-      assert.areSame(CKEDITOR.TRISTATE_OFF, formatCombo._.state, "check state OFF");
 
       bot.combo(comboName, function (combo) {
-        assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
         // click pre
         combo.onClick("pre");
         assert.areSame(

--- a/tests/structuredheadings/setnumberingstyle.js
+++ b/tests/structuredheadings/setnumberingstyle.js
@@ -69,13 +69,9 @@
     },
     "attempt to apply numbering style to a range containing non-haedings": function () {
       var bot = this.editorBot;
-      var ed = this.editor;
       bot.setHtmlWithSelection("[<h1>foo</h1><p>bar</p><h1>baz]</h1>");
-      var styleCombo = ed.ui.get(comboName);
-      assert.areSame(CKEDITOR.TRISTATE_OFF, styleCombo._.state, "check state OFF");
 
       bot.combo(comboName, function (combo) {
-        assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
         combo.onClick("1. a. i. a. i.");
         assert.areSame(
             "<h1 class=\"autonumber autonumber-0 autonumber-N\">foo</h1>" +

--- a/tests/structuredheadings/setnumberingstyle.js
+++ b/tests/structuredheadings/setnumberingstyle.js
@@ -4,6 +4,8 @@
 // Clean up all instances been created on the page.
 (function () {
 
+  var comboName = "NumStyles";
+
   bender.editor = {
     allowedForTests: "h1; h2; p"
   };
@@ -16,11 +18,10 @@
       var bot = this.editorBot;
       var ed = this.editor;
       bot.setHtmlWithSelection("<h1>^foo</h1>");
-      var name = "NumStyles";
-      var styleCombo = ed.ui.get(name);
+      var styleCombo = ed.ui.get(comboName);
       assert.areSame(CKEDITOR.TRISTATE_OFF, styleCombo._.state, "check state OFF");
 
-      bot.combo(name, function (combo) {
+      bot.combo(comboName, function (combo) {
         assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
         combo.onClick("1. a. i. a. i.");
         assert.areSame(
@@ -34,11 +35,10 @@
       var bot = this.editorBot;
       var ed = this.editor;
       bot.setHtmlWithSelection("[<h1>foo</h1><h1>bar</h1>]");
-      var name = "NumStyles";
-      var styleCombo = ed.ui.get(name);
+      var styleCombo = ed.ui.get(comboName);
       assert.areSame(CKEDITOR.TRISTATE_OFF, styleCombo._.state, "check state OFF");
 
-      bot.combo(name, function (combo) {
+      bot.combo(comboName, function (combo) {
         assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
         combo.onClick("1. a. i. a. i.");
         assert.areSame(
@@ -53,11 +53,10 @@
       var bot = this.editorBot;
       var ed = this.editor;
       bot.setHtmlWithSelection("[<h1>foo</h1><h1>b]ar</h1>");
-      var name = "NumStyles";
-      var styleCombo = ed.ui.get(name);
+      var styleCombo = ed.ui.get(comboName);
       assert.areSame(CKEDITOR.TRISTATE_OFF, styleCombo._.state, "check state OFF");
 
-      bot.combo(name, function (combo) {
+      bot.combo(comboName, function (combo) {
         assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
         combo.onClick("1. a. i. a. i.");
         assert.areSame(

--- a/tests/structuredheadings/setnumberingstyle.js
+++ b/tests/structuredheadings/setnumberingstyle.js
@@ -66,6 +66,25 @@
             "applied 1aiai to both h1"
         );
       });
+    },
+    "attempt to apply numbering style to a range containing non-haedings": function () {
+      var bot = this.editorBot;
+      var ed = this.editor;
+      bot.setHtmlWithSelection("[<h1>foo</h1><p>bar</p><h1>baz]</h1>");
+      var styleCombo = ed.ui.get(comboName);
+      assert.areSame(CKEDITOR.TRISTATE_OFF, styleCombo._.state, "check state OFF");
+
+      bot.combo(comboName, function (combo) {
+        assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
+        combo.onClick("1. a. i. a. i.");
+        assert.areSame(
+            "<h1 class=\"autonumber autonumber-0 autonumber-N\">foo</h1>" +
+            "<p>bar</p>" +
+            "<h1 class=\"autonumber autonumber-0 autonumber-N\">baz</h1>",
+            bot.getData(),
+            "applied 1aiai to both h1 and p is intact"
+        );
+      });
     }
   });
 })();

--- a/tests/structuredheadings/setnumberingstyle.js
+++ b/tests/structuredheadings/setnumberingstyle.js
@@ -1,0 +1,15 @@
+/* bender-tags: editor,unit */
+/* bender-ckeditor-plugins: wysiwygarea,structuredheadings,toolbar,basicstyles,dialog,richcombo */
+
+// Clean up all instances been created on the page.
+(function () {
+
+  bender.editor = {
+    allowedForTests: "h1; h2; p"
+  };
+
+  bender.test({
+    setUp: function () {
+      //Anything to be run before each test if needed
+    },
+})();

--- a/tests/structuredheadings/setnumberingstyle.js
+++ b/tests/structuredheadings/setnumberingstyle.js
@@ -29,6 +29,25 @@
             "applied 1aiai to h1"
         );
       });
+    },
+    "apply numbering style to multiple non-autonumbered h1": function () {
+      var bot = this.editorBot;
+      var ed = this.editor;
+      bot.setHtmlWithSelection("[<h1>foo</h1><h1>bar</h1>]");
+      var name = "NumStyles";
+      var styleCombo = ed.ui.get(name);
+      assert.areSame(CKEDITOR.TRISTATE_OFF, styleCombo._.state, "check state OFF");
+
+      bot.combo(name, function (combo) {
+        assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
+        combo.onClick("1. a. i. a. i.");
+        assert.areSame(
+            "<h1 class=\"autonumber autonumber-0 autonumber-N\">foo</h1>" +
+            "<h1 class=\"autonumber autonumber-0 autonumber-N\">bar</h1>",
+            bot.htmlWithSelection(),
+            "applied 1aiai to both h1"
+        );
+      });
     }
   });
 })();

--- a/tests/structuredheadings/setnumberingstyle.js
+++ b/tests/structuredheadings/setnumberingstyle.js
@@ -44,7 +44,7 @@
         assert.areSame(
             "<h1 class=\"autonumber autonumber-0 autonumber-N\">foo</h1>" +
             "<h1 class=\"autonumber autonumber-0 autonumber-N\">bar</h1>",
-            bot.htmlWithSelection(),
+            bot.getData(),
             "applied 1aiai to both h1"
         );
       });
@@ -63,7 +63,7 @@
         assert.areSame(
             "<h1 class=\"autonumber autonumber-0 autonumber-N\">foo</h1>" +
             "<h1 class=\"autonumber autonumber-0 autonumber-N\">bar</h1>",
-            bot.htmlWithSelection(),
+            bot.getData(),
             "applied 1aiai to both h1"
         );
       });

--- a/tests/structuredheadings/setnumberingstyle.js
+++ b/tests/structuredheadings/setnumberingstyle.js
@@ -67,7 +67,7 @@
         );
       });
     },
-    "attempt to apply numbering style to a range containing non-haedings": function () {
+    "attempt to apply numbering style to a range containing non-headings": function () {
       var bot = this.editorBot;
       bot.setHtmlWithSelection("[<h1>foo</h1><p>bar</p><h1>baz]</h1>");
 
@@ -79,6 +79,22 @@
             "<h1 class=\"autonumber autonumber-0 autonumber-N\">baz</h1>",
             bot.getData(),
             "applied 1aiai to both h1 and p is intact"
+        );
+      });
+    },
+    "preserves existing autonumbered headings in a mix": function () {
+      var bot = this.editorBot;
+      bot.setHtmlWithSelection(
+        "[<h1 class=\"autonumber autonumber-0 autonumber-N\">foo</h1><h1>bar]</h1>"
+      );
+
+      bot.combo(comboName, function (combo) {
+        combo.onClick("1. a. i. a. i.");
+        assert.areSame(
+            "<h1 class=\"autonumber autonumber-0 autonumber-N\">foo</h1>" +
+            "<h1 class=\"autonumber autonumber-0 autonumber-N\">bar</h1>",
+            bot.getData(),
+            "applied 1aiai to second h1 and first h1 is intact"
         );
       });
     }

--- a/tests/structuredheadings/setnumberingstyle.js
+++ b/tests/structuredheadings/setnumberingstyle.js
@@ -12,4 +12,23 @@
     setUp: function () {
       //Anything to be run before each test if needed
     },
+    "apply numbering style to a non-autonumbered heading": function () {
+      var bot = this.editorBot;
+      var ed = this.editor;
+      bot.setHtmlWithSelection("<h1>^foo</h1>");
+      var name = "NumStyles";
+      var styleCombo = ed.ui.get(name);
+      assert.areSame(CKEDITOR.TRISTATE_OFF, styleCombo._.state, "check state OFF");
+
+      bot.combo(name, function (combo) {
+        assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
+        combo.onClick("1. a. i. a. i.");
+        assert.areSame(
+            "<h1 class=\"autonumber autonumber-0 autonumber-N\">^foo</h1>",
+            bot.htmlWithSelection(),
+            "applied 1aiai to h1"
+        );
+      });
+    }
+  });
 })();

--- a/tests/structuredheadings/setnumberingstyle.js
+++ b/tests/structuredheadings/setnumberingstyle.js
@@ -16,13 +16,9 @@
     },
     "apply numbering style to a non-autonumbered heading": function () {
       var bot = this.editorBot;
-      var ed = this.editor;
       bot.setHtmlWithSelection("<h1>^foo</h1>");
-      var styleCombo = ed.ui.get(comboName);
-      assert.areSame(CKEDITOR.TRISTATE_OFF, styleCombo._.state, "check state OFF");
 
       bot.combo(comboName, function (combo) {
-        assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
         combo.onClick("1. a. i. a. i.");
         assert.areSame(
             "<h1 class=\"autonumber autonumber-0 autonumber-N\">^foo</h1>",
@@ -33,13 +29,9 @@
     },
     "apply numbering style to multiple non-autonumbered h1": function () {
       var bot = this.editorBot;
-      var ed = this.editor;
       bot.setHtmlWithSelection("[<h1>foo</h1><h1>bar</h1>]");
-      var styleCombo = ed.ui.get(comboName);
-      assert.areSame(CKEDITOR.TRISTATE_OFF, styleCombo._.state, "check state OFF");
 
       bot.combo(comboName, function (combo) {
-        assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
         combo.onClick("1. a. i. a. i.");
         assert.areSame(
             "<h1 class=\"autonumber autonumber-0 autonumber-N\">foo</h1>" +
@@ -51,13 +43,9 @@
     },
     "apply numbering style to multiple non-autonumbered h1 using a partial selection": function () {
       var bot = this.editorBot;
-      var ed = this.editor;
       bot.setHtmlWithSelection("[<h1>foo</h1><h1>b]ar</h1>");
-      var styleCombo = ed.ui.get(comboName);
-      assert.areSame(CKEDITOR.TRISTATE_OFF, styleCombo._.state, "check state OFF");
 
       bot.combo(comboName, function (combo) {
-        assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
         combo.onClick("1. a. i. a. i.");
         assert.areSame(
             "<h1 class=\"autonumber autonumber-0 autonumber-N\">foo</h1>" +

--- a/tests/structuredheadings/setnumberingstyle.js
+++ b/tests/structuredheadings/setnumberingstyle.js
@@ -48,6 +48,25 @@
             "applied 1aiai to both h1"
         );
       });
+    },
+    "apply numbering style to multiple non-autonumbered h1 using a partial selection": function () {
+      var bot = this.editorBot;
+      var ed = this.editor;
+      bot.setHtmlWithSelection("[<h1>foo</h1><h1>b]ar</h1>");
+      var name = "NumStyles";
+      var styleCombo = ed.ui.get(name);
+      assert.areSame(CKEDITOR.TRISTATE_OFF, styleCombo._.state, "check state OFF");
+
+      bot.combo(name, function (combo) {
+        assert.areSame(CKEDITOR.TRISTATE_ON, combo._.state, "check state ON when opened");
+        combo.onClick("1. a. i. a. i.");
+        assert.areSame(
+            "<h1 class=\"autonumber autonumber-0 autonumber-N\">foo</h1>" +
+            "<h1 class=\"autonumber autonumber-0 autonumber-N\">bar</h1>",
+            bot.htmlWithSelection(),
+            "applied 1aiai to both h1"
+        );
+      });
     }
   });
 })();


### PR DESCRIPTION
Fixes #41 - noncollapsed selection -> setting heading types 

Now, we can convert multiple headings at once to be autonumbered (by selecting them) 