### PR TITLE
Fix #49 - clean css when setting ranges of paragraph/pre

### DIFF
--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -413,7 +413,7 @@
       }
 
       var walker = new CKEDITOR.dom.walker(range); // eslint-disable-line new-cap
-      walker.evaluator = function (node) {
+      walker.evaluator = function isHeading(node) {
         if (node.type !== CKEDITOR.NODE_ELEMENT) {
           return false;
         }

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -451,7 +451,7 @@
     },
     clearAllFromRange: function (editor, range) {
       var walker = new CKEDITOR.dom.walker(range); // eslint-disable-line new-cap
-      walker.evaluator = function (node) {
+      walker.evaluator = function isParaPreOrHeading(node) {
         if (node.type !== CKEDITOR.NODE_ELEMENT) {
           return false;
         }

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -443,7 +443,6 @@
             editor,
             CKEDITOR.plugins.structuredheadings.getCurrentBlockFromPath(editor)
           );
-          return;
         } else {
           this.clearAllFromRange(editor, range);
         }

--- a/tests/structuredheadings/formatcombo.js
+++ b/tests/structuredheadings/formatcombo.js
@@ -94,6 +94,22 @@
         );
       });
     },
+
+    "p on autonumbered heading in range removes classes": function () {
+      var bot = this.editorBot;
+      bot.setHtmlWithSelection("[<p>foo</p><h1 class=\"autonumber autonumber-0\">bar</h1><p>baz</p>]");
+
+      bot.combo(comboName, function (combo) {
+        // click p
+        combo.onClick("p");
+        assert.areSame(
+            "<p>foo</p><p>bar</p><p>baz</p>",
+            bot.getData(),
+            "applied p to h1 and it is classless"
+        );
+      });
+    },
+
     "pre option on a p": function () {
       var bot = this.editorBot;
       bot.setHtmlWithSelection("<p>^foo</p>");

--- a/tests/structuredheadings/formatcombo.js
+++ b/tests/structuredheadings/formatcombo.js
@@ -97,7 +97,11 @@
 
     "p on autonumbered heading in range removes classes": function () {
       var bot = this.editorBot;
-      bot.setHtmlWithSelection("[<p>foo</p><h1 class=\"autonumber autonumber-0\">bar</h1><p>baz</p>]");
+      bot.setHtmlWithSelection(
+        "[<p>foo</p>" +
+        "<h1 class=\"autonumber autonumber-0\">bar</h1>" +
+        "<p>baz</p>]"
+        );
 
       bot.combo(comboName, function (combo) {
         // click p


### PR DESCRIPTION
It probably needs more refactoring love in the future, but this fixes cases where you get stuck with numbering on a paragraph.  Jana especially runs into this one in usability test resetting so it'd be nice to get in place just for that.  