### PR TITLE
Fix #50 - Undo doesn't work for many of the structured headings functionality

### DIFF
--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -388,8 +388,6 @@
           return;
         }
 
-        editor.fire("saveSnapshot");
-
         if (evt.data.keyCode === TAB_KEY_CODE) {
           editor.execCommand("increaseHeadingLevel");
           evt.cancel();
@@ -397,8 +395,6 @@
           editor.execCommand("decreaseHeadingLevel");
           evt.cancel();
         }
-
-        editor.fire("saveSnapshot");
 
       }, this, null, 1);
 

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -216,6 +216,7 @@
         },
 
         onClick: function (value) {
+          editor.fire("saveSnapshot");
           editor.applyStyle(elementStyles[ value ]);
           var block = editor.elementPath().block;
           var previousHeading = getPreviousHeading(editor, block);
@@ -238,6 +239,7 @@
                 ].slice(1));
           }
 
+          editor.fire("saveSnapshot");
         },
 
         onRender: function () {
@@ -307,6 +309,7 @@
         },
 
         onClick: function (value) {
+          editor.fire("saveSnapshot");
           if (value === "restart") {
             editor.execCommand("restartNumbering");
             return;
@@ -334,7 +337,7 @@
           editor.execCommand("reapplyStyle", value);
           // set the combo box value
           this.setValue(value, value);
-
+          editor.fire("saveSnapshot");
         },
 
         onRender: function () {

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -307,8 +307,9 @@
           setLevel(editor, heading);
           setCurrentStyle(editor, heading, value);
         },
-        onClick: function (value) {
+        onClick: function (value) {  // eslint-disable-line max-statements
           editor.fire("saveSnapshot");
+
           if (value === "restart") {
             editor.execCommand("restartNumbering");
             editor.fire("saveSnapshot");

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -388,6 +388,8 @@
           return;
         }
 
+        editor.fire("saveSnapshot");
+
         if (evt.data.keyCode === TAB_KEY_CODE) {
           editor.execCommand("increaseHeadingLevel");
           evt.cancel();
@@ -395,6 +397,8 @@
           editor.execCommand("decreaseHeadingLevel");
           evt.cancel();
         }
+
+        editor.fire("saveSnapshot");
 
       }, this, null, 1);
 

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -307,11 +307,11 @@
           setLevel(editor, heading);
           setCurrentStyle(editor, heading, value);
         },
-
         onClick: function (value) {
           editor.fire("saveSnapshot");
           if (value === "restart") {
             editor.execCommand("restartNumbering");
+            editor.fire("saveSnapshot");
             return;
           }
           var selection = editor.getSelection();
@@ -334,10 +334,11 @@
           }
 
           // apply the correct bulletstyle for all numbered headings
+          editor.fire("lockSnapshot");
           editor.execCommand("reapplyStyle", value);
           // set the combo box value
           this.setValue(value, value);
-          editor.fire("saveSnapshot");
+          editor.fire("unlockSnapshot");
         },
 
         onRender: function () {

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -336,6 +336,9 @@
 
           // apply the correct bulletstyle for all numbered headings
           editor.fire("lockSnapshot");
+          // the snapshot needs to be locked here, because
+          // execCommand will also create a snapshot, leading to
+          // an intermediate snapshot with some of the styles applied, but not all
           editor.execCommand("reapplyStyle", value);
           // set the combo box value
           this.setValue(value, value);

--- a/tests/structuredheadings/clearnumberingstyle.js
+++ b/tests/structuredheadings/clearnumberingstyle.js
@@ -41,7 +41,8 @@
     },
     "clear numbering style to multiple autonumbered h1": function () {
       var bot = this.editorBot;
-      var initialHtmlWithSelection = "[<h1 class=\"autonumber autonumber-0 autonumber-N\">foo</h1>" +
+      var initialHtmlWithSelection =
+        "[<h1 class=\"autonumber autonumber-0 autonumber-N\">foo</h1>" +
         "<p>bar</p>" +
         "<h1 class=\"autonumber autonumber-0 autonumber-N\">baz</h1>]";
       bot.setHtmlWithSelection(initialHtmlWithSelection);

--- a/tests/structuredheadings/clearnumberingstyle.js
+++ b/tests/structuredheadings/clearnumberingstyle.js
@@ -1,5 +1,7 @@
+/* eslint-disable */
 /* bender-tags: editor,unit */
 /* bender-ckeditor-plugins: wysiwygarea,structuredheadings,toolbar,basicstyles,dialog,richcombo,undo */
+/* eslint-enable */
 
 // Clean up all instances been created on the page.
 (function () {

--- a/tests/structuredheadings/clearnumberingstyle.js
+++ b/tests/structuredheadings/clearnumberingstyle.js
@@ -1,5 +1,5 @@
 /* bender-tags: editor,unit */
-/* bender-ckeditor-plugins: wysiwygarea,structuredheadings,toolbar,basicstyles,dialog,richcombo */
+/* bender-ckeditor-plugins: wysiwygarea,structuredheadings,toolbar,basicstyles,dialog,richcombo,undo */
 
 // Clean up all instances been created on the page.
 (function () {
@@ -53,10 +53,11 @@
         );
 
         bot.execCommand("undo");
-
+        // this is weird, but the selection API returns the extra (internal) paragraphs
+        // that are created to normalize the selection here
         assert.areSame(
-          initialHtmlWithSelection,
-          bot.htmlWithSelection(),
+          initialHtmlWithSelection.substring(1, initialHtmlWithSelection.length - 1),
+          bot.getData(),
           "undo the dropdown"
         );
       });

--- a/tests/structuredheadings/clearnumberingstyle.js
+++ b/tests/structuredheadings/clearnumberingstyle.js
@@ -17,7 +17,8 @@
     },
     "clear numbering style to a single autonumbered heading": function () {
       var bot = this.editorBot;
-      bot.setHtmlWithSelection("<h1 class=\"autonumber autonumber-0 autonumber-N\">^foo</h1>");
+      var initialHtmlWithSelection = "<h1 class=\"autonumber autonumber-0 autonumber-N\">^foo</h1>";
+      bot.setHtmlWithSelection(initialHtmlWithSelection);
 
       bot.combo(comboName, function (combo) {
         combo.onClick(itemName);
@@ -26,15 +27,22 @@
             bot.htmlWithSelection(),
             "cleared styling from h1"
         );
+
+        bot.execCommand("undo");
+
+        assert.areSame(
+          initialHtmlWithSelection,
+          bot.htmlWithSelection(),
+          "undo the dropdown"
+        );
       });
     },
     "clear numbering style to multiple autonumbered h1": function () {
       var bot = this.editorBot;
-      bot.setHtmlWithSelection(
-        "[<h1 class=\"autonumber autonumber-0 autonumber-N\">foo</h1>" +
+      var initialHtmlWithSelection = "[<h1 class=\"autonumber autonumber-0 autonumber-N\">foo</h1>" +
         "<p>bar</p>" +
-        "<h1 class=\"autonumber autonumber-0 autonumber-N\">baz</h1>]"
-      );
+        "<h1 class=\"autonumber autonumber-0 autonumber-N\">baz</h1>]";
+      bot.setHtmlWithSelection(initialHtmlWithSelection);
 
       bot.combo(comboName, function (combo) {
         combo.onClick(itemName);
@@ -42,6 +50,14 @@
             "<h1>foo</h1><p>bar</p><h1>baz</h1>",
             bot.getData(),
             "cleared styling from headings"
+        );
+
+        bot.execCommand("undo");
+
+        assert.areSame(
+          initialHtmlWithSelection,
+          bot.htmlWithSelection(),
+          "undo the dropdown"
         );
       });
     },

--- a/tests/structuredheadings/clearnumberingstyle.js
+++ b/tests/structuredheadings/clearnumberingstyle.js
@@ -45,6 +45,10 @@
         "[<h1 class=\"autonumber autonumber-0 autonumber-N\">foo</h1>" +
         "<p>bar</p>" +
         "<h1 class=\"autonumber autonumber-0 autonumber-N\">baz</h1>]";
+      var initialHtmlWithoutSelection = initialHtmlWithSelection.substring(
+        1,
+        initialHtmlWithSelection.length - 1
+      );
       bot.setHtmlWithSelection(initialHtmlWithSelection);
 
       bot.combo(comboName, function (combo) {
@@ -59,7 +63,7 @@
         // this is weird, but the selection API returns the extra (internal) paragraphs
         // that are created to normalize the selection here
         assert.areSame(
-          initialHtmlWithSelection.substring(1, initialHtmlWithSelection.length - 1),
+          initialHtmlWithoutSelection,
           bot.getData(),
           "undo the dropdown"
         );

--- a/tests/structuredheadings/formatcombo.js
+++ b/tests/structuredheadings/formatcombo.js
@@ -96,6 +96,7 @@
         );
       });
     },
+
     "pre option on a p": function () {
       var bot = this.editorBot;
       bot.setHtmlWithSelection("<p>^foo</p>");
@@ -128,7 +129,8 @@
 
     "autonumbered heading is undoable": function () {
       var bot = this.editorBot;
-      bot.setHtmlWithSelection("<p>^foo</p>");
+      var initialHtmlWithSelection = "<p>^foo</p>";
+      bot.setHtmlWithSelection(initialHtmlWithSelection);
 
       bot.combo(comboName, function (combo) {
         // click h2
@@ -142,9 +144,56 @@
 
         bot.execCommand("undo");
         assert.areSame(
-            "<p>^foo</p>",
+            initialHtmlWithSelection,
             bot.htmlWithSelection(),
             "undid the heading"
+        );
+      });
+    },
+
+    "pre is undoable": function () {
+      var bot = this.editorBot;
+      var initialHtmlWithSelection = "<h1 class=\"autonumber autonumber-0\">^foo</h1>";
+      bot.setHtmlWithSelection(initialHtmlWithSelection);
+
+      bot.combo(comboName, function (combo) {
+        // click pre
+        combo.onClick("pre");
+        assert.areSame(
+            "<pre>^foo</pre>",
+            bot.htmlWithSelection(),
+            "applied pre to h1"
+        );
+
+        bot.execCommand("undo");
+        assert.areSame(
+          initialHtmlWithSelection,
+          bot.htmlWithSelection(),
+          "undid the pre"
+        );
+      });
+    },
+
+    "p on autonumbered heading is undoable": function () {
+      var bot = this.editorBot;
+      var initialHtmlWithSelection = "<h1 class=\"autonumber autonumber-0\">^foo</h1>";
+      bot.setHtmlWithSelection(initialHtmlWithSelection);
+
+      bot.combo(comboName, function (combo) {
+        // click p
+        combo.onClick("p");
+        assert.areSame(
+            "<p>^foo</p>",
+            bot.htmlWithSelection(),
+            "applied p to h1"
+        );
+
+        bot.execCommand("undo");
+
+        assert.areSame(
+          initialHtmlWithSelection,
+          bot.htmlWithSelection(),
+          "undid the p"
         );
       });
     }

--- a/tests/structuredheadings/formatcombo.js
+++ b/tests/structuredheadings/formatcombo.js
@@ -1,5 +1,7 @@
+/* eslint-disable */
 /* bender-tags: editor,unit */
-/* bender-ckeditor-plugins: wysiwygarea,structuredheadings,toolbar,basicstyles,dialog,richcombo */
+/* bender-ckeditor-plugins: wysiwygarea,structuredheadings,toolbar,basicstyles,dialog,richcombo,undo */
+/* eslint-enable */
 
 // Clean up all instances been created on the page.
 (function () {

--- a/tests/structuredheadings/formatcombo.js
+++ b/tests/structuredheadings/formatcombo.js
@@ -124,6 +124,29 @@
             "applied pre to h1"
         );
       });
+    },
+
+    "autonumbered heading is undoable": function () {
+      var bot = this.editorBot;
+      bot.setHtmlWithSelection("<p>^foo</p>");
+
+      bot.combo(comboName, function (combo) {
+        // click h2
+        combo.onClick("h2");
+        // the new h2 has autonumbering set, since no prior heading exists
+        assert.areSame(
+            "<h2 class=\"autonumber autonumber-1\">^foo</h2>",
+            bot.htmlWithSelection(),
+            "applied h2 block autonumberstyle"
+        );
+
+        bot.execCommand("undo");
+        assert.areSame(
+            "<p>^foo</p>",
+            bot.htmlWithSelection(),
+            "undid the heading"
+        );
+      });
     }
 
   });

--- a/tests/structuredheadings/keyboardshortcuts.js
+++ b/tests/structuredheadings/keyboardshortcuts.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 /* bender-tags: editor,unit */
-/* bender-ckeditor-plugins: wysiwygarea,structuredheadings,toolbar,basicstyles,dialog,richcombo,indentlist,list */
+/* bender-ckeditor-plugins: wysiwygarea,structuredheadings,toolbar,basicstyles,dialog,richcombo,indentlist,list,undo */
 /* eslint-enable */
 
 // Clean up all instances been created on the page.

--- a/tests/structuredheadings/keyboardshortcuts.js
+++ b/tests/structuredheadings/keyboardshortcuts.js
@@ -18,7 +18,9 @@
     },
 
     "H2 to H3 from Tab": function () {
-      this.editorBot.setHtmlWithSelection("<h2>^Heading</h2>");
+      var bot = this.editorBot;
+      var initialHtmlWithSelection = "<h2>^Heading</h2>";
+      bot.setHtmlWithSelection(initialHtmlWithSelection);
       this.editor.editable().fire(
         "keydown",
         new CKEDITOR.dom.event({ keyCode: tabKey }) // eslint-disable-line new-cap
@@ -29,10 +31,20 @@
         "<h3>^Heading</h3>", updatedContent,
         "Header increased from TAB"
       );
+
+      bot.execCommand("undo");
+
+      assert.areSame(
+        initialHtmlWithSelection,
+        bender.tools.getHtmlWithSelection(this.editorBot.editor),
+        "tab is undoable"
+      );
     },
 
     "H2 to H1 from Shift-Tab": function () {
-      this.editorBot.setHtmlWithSelection("<h2>^Heading</h2>");
+      var bot = this.editorBot;
+      var initialHtmlWithSelection = "<h2>^Heading</h2>";
+      bot.setHtmlWithSelection(initialHtmlWithSelection);
       this.editor.editable().fire(
         "keydown",
         new CKEDITOR.dom.event({ keyCode: tabKey, shiftKey: true }) // eslint-disable-line new-cap
@@ -42,7 +54,15 @@
       assert.areSame(
           "<h1>^Heading</h1>", updatedContent,
           "Header decreased from Shift-TAB"
-        );
+      );
+
+      bot.execCommand("undo");
+
+      assert.areSame(
+        initialHtmlWithSelection,
+        bender.tools.getHtmlWithSelection(this.editorBot.editor),
+        "tab is undoable"
+      );
     },
 
     "list tab still works": function () {

--- a/tests/structuredheadings/setnumberingstyle.js
+++ b/tests/structuredheadings/setnumberingstyle.js
@@ -85,6 +85,28 @@
             "applied 1aiai to second h1 and first h1 is intact"
         );
       });
+    },
+    "undo applying numbering style to a non-autonumbered heading": function () {
+      var bot = this.editorBot;
+      var initialHtmlWithSelection = "<h1>^foo</h1>";
+      bot.setHtmlWithSelection(initialHtmlWithSelection);
+
+      bot.combo(comboName, function (combo) {
+        combo.onClick("1. a. i. a. i.");
+        assert.areSame(
+            "<h1 class=\"autonumber autonumber-0 autonumber-N\">^foo</h1>",
+            bot.htmlWithSelection(),
+            "applied 1aiai to h1"
+        );
+
+        bot.execCommand("undo");
+
+        assert.areSame(
+          initialHtmlWithSelection,
+          bot.htmlWithSelection(),
+          "undid the numbering style"
+        );
+      });
     }
   });
 })();

--- a/tests/structuredheadings/setnumberingstyle.js
+++ b/tests/structuredheadings/setnumberingstyle.js
@@ -1,5 +1,7 @@
+/* eslint-disable */
 /* bender-tags: editor,unit */
-/* bender-ckeditor-plugins: wysiwygarea,structuredheadings,toolbar,basicstyles,dialog,richcombo */
+/* bender-ckeditor-plugins: wysiwygarea,structuredheadings,toolbar,basicstyles,dialog,richcombo,undo */
+/* eslint-enable */
 
 // Clean up all instances been created on the page.
 (function () {


### PR DESCRIPTION
Notably, it's completely busted for tab/shift tab, as well as any of the dropdown options.  