### PR TITLE
Fix #55 - allow numbering paragraphs

### DIFF
--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -322,10 +322,25 @@
               );
           var func;
 
+          // handle the collapsed, not in a heading case
+          if (headings === null) {
+            editor.fire("lockSnapshot");
+            editor.execCommand("matchHeading");
+            editor.fire("unlockSnapshot");
+            // put the new heading into the headings array
+            headings = [CKEDITOR.plugins.structuredheadings.getCurrentBlockFromPath(editor)];
+          }
+
           if (value === "clear") {
             func = this.clearAutonumberClassesForHeading;
           } else {
             func = this.setAutonumberClassesForHeading.bind(this, value);
+          }
+
+          if (headings && headings.length > 0) {
+            for (var i = 0; i < headings.length; i++) {
+              func(headings[i]);
+            }
           }
 
           editor.fire("lockSnapshot");
@@ -333,21 +348,7 @@
           // execCommand will also create a snapshot, leading to
           // an intermediate snapshot with some of the styles applied, but not all
 
-          // handle the collapsed, not in a heading case
-          if (headings === null) {
-            editor.execCommand("matchHeading");
-            // put the new heading into the headings array
-            headings = [CKEDITOR.plugins.structuredheadings.getCurrentBlockFromPath(editor)];
-          }
-
-          if (headings.length > 0) {
-            for (var i = 0; i < headings.length; i++) {
-              func(headings[i]);
-            }
-          }
-
           // apply the correct bulletstyle for all numbered headings
-
           editor.execCommand("reapplyStyle", value);
           // set the combo box value
           this.setValue(value, value);

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -324,7 +324,7 @@
 
           // handle the collapsed, not in a heading case
           if (headings === null) {
-            editor.fire("lockSnapshot");
+            editor.fire("lockSnapshot", { dontUpdate: true });
             editor.execCommand("matchHeading");
             editor.fire("unlockSnapshot");
             // put the new heading into the headings array

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -363,19 +363,6 @@
 
         onOpen: function () {
           this.showAll();
-        },
-
-        refresh: function () {
-          var path = editor.elementPath();
-
-          if (!path) {return;}
-
-          if (path.block && editor.config.numberedElements.indexOf(path.block.getName()) >= 0) {
-            this.setState(CKEDITOR.TRISTATE_OFF);
-            return;
-          }
-
-          this.setState(CKEDITOR.TRISTATE_DISABLED);
         }
       });
 

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -329,6 +329,7 @@
 
              // prep the html for the collapsed, not in a heading case
             if (headings === null) {
+              // avoid an extra snapshot created by the matchHeading command
               editor.fire("lockSnapshot", { dontUpdate: true });
               editor.execCommand("matchHeading");
               editor.fire("unlockSnapshot");

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -337,7 +337,7 @@
             }
           }
 
-          if (headings.length > 0) {
+          if (headings !== null && headings.length > 0) {
             for (var i = 0; i < headings.length; i++) {
               func(headings[i]);
             }

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -337,7 +337,7 @@
             func = this.setAutonumberClassesForHeading.bind(this, value);
           }
 
-          if (headings && headings.length > 0) {
+          if (headings.length > 0) {
             for (var i = 0; i < headings.length; i++) {
               func(headings[i]);
             }

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -338,7 +338,7 @@
             }
           }
 
-          if (headings !== null && headings.length > 0) {
+          if (headings) {
             for (var i = 0; i < headings.length; i++) {
               func(headings[i]);
             }

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -322,19 +322,19 @@
               );
           var func;
 
-          // handle the collapsed, not in a heading case
-          if (headings === null) {
-            editor.fire("lockSnapshot", { dontUpdate: true });
-            editor.execCommand("matchHeading");
-            editor.fire("unlockSnapshot");
-            // put the new heading into the headings array
-            headings = [CKEDITOR.plugins.structuredheadings.getCurrentBlockFromPath(editor)];
-          }
-
           if (value === "clear") {
             func = this.clearAutonumberClassesForHeading;
           } else {
             func = this.setAutonumberClassesForHeading.bind(this, value);
+
+             // prep the html for the collapsed, not in a heading case
+            if (headings === null) {
+              editor.fire("lockSnapshot", { dontUpdate: true });
+              editor.execCommand("matchHeading");
+              editor.fire("unlockSnapshot");
+              // put the new heading into the headings array
+              headings = [CKEDITOR.plugins.structuredheadings.getCurrentBlockFromPath(editor)];
+            }
           }
 
           if (headings.length > 0) {

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -328,6 +328,18 @@
             func = this.setAutonumberClassesForHeading.bind(this, value);
           }
 
+          editor.fire("lockSnapshot");
+          // the snapshot needs to be locked here, because
+          // execCommand will also create a snapshot, leading to
+          // an intermediate snapshot with some of the styles applied, but not all
+
+          // handle the collapsed, not in a heading case
+          if (headings === null) {
+            editor.execCommand("matchHeading");
+            // put the new heading into the headings array
+            headings = [CKEDITOR.plugins.structuredheadings.getCurrentBlockFromPath(editor)];
+          }
+
           if (headings.length > 0) {
             for (var i = 0; i < headings.length; i++) {
               func(headings[i]);
@@ -335,10 +347,7 @@
           }
 
           // apply the correct bulletstyle for all numbered headings
-          editor.fire("lockSnapshot");
-          // the snapshot needs to be locked here, because
-          // execCommand will also create a snapshot, leading to
-          // an intermediate snapshot with some of the styles applied, but not all
+
           editor.execCommand("reapplyStyle", value);
           // set the combo box value
           this.setValue(value, value);
@@ -405,7 +414,9 @@
         if (editor.config.numberedElements.indexOf(block.getName()) !== -1) {
           return [block];
         }
-        return [];
+        // we were in a collapsed selection, but it isn't a heading
+
+        return null;
       }
 
       var walker = new CKEDITOR.dom.walker(range); // eslint-disable-line new-cap

--- a/tests/structuredheadings/clearnumberingstyle.js
+++ b/tests/structuredheadings/clearnumberingstyle.js
@@ -83,6 +83,20 @@
             "didn't do anything"
         );
       });
+    },
+    "clear numbering style no-op on p": function () {
+      var bot = this.editorBot;
+      var initialHtmlWithSelection = "<p>^foo</p>";
+      bot.setHtmlWithSelection(initialHtmlWithSelection);
+
+      bot.combo(comboName, function (combo) {
+        combo.onClick(itemName);
+        assert.areSame(
+            initialHtmlWithSelection,
+            bot.htmlWithSelection(),
+            "didn't do anything"
+        );
+      });
     }
   });
 })();

--- a/tests/structuredheadings/setnumberingstyle.js
+++ b/tests/structuredheadings/setnumberingstyle.js
@@ -120,6 +120,19 @@
           "undid the numbering style"
         );
       });
-    }
+    },
+    "apply numbering style to a paragraph, so it becomes a heading": function () {
+      var bot = this.editorBot;
+      bot.setHtmlWithSelection("<p>^foo</p>");
+
+      bot.combo(comboName, function (combo) {
+        combo.onClick("1. a. i. a. i.");
+        assert.areSame(
+            "<h1 class=\"autonumber autonumber-0 autonumber-N\">^foo</h1>",
+            bot.htmlWithSelection(),
+            "applied 1aiai to p, and it became an h1"
+        );
+      });
+    },
   });
 })();

--- a/tests/structuredheadings/setnumberingstyle.js
+++ b/tests/structuredheadings/setnumberingstyle.js
@@ -144,7 +144,7 @@
         assert.areSame(
             "<h2>foo</h2>" +
             "<p>bar</p>" +
-            "<h2 class=\"autonumber autonumber-1 autonumber-N\">^baz</h2>",
+            "<h2 class=\"autonumber autonumber-1 autonumber-a\">^baz</h2>",
             bot.htmlWithSelection(),
             "applied 1aiai to p, and it became an h2 at the right level"
         );

--- a/tests/structuredheadings/setnumberingstyle.js
+++ b/tests/structuredheadings/setnumberingstyle.js
@@ -141,15 +141,14 @@
       bot.combo(comboName, function (combo) {
         combo.onClick("1. a. i. a. i.");
         // this is an interesting case.  should the prior unnumbered heading be numbered?
-        // probably not.
         assert.areSame(
             "<h2>foo</h2>" +
             "<p>bar</p>" +
-            "<h2 class=\"autonumber autonumber-0 autonumber-N\">^baz</h2>",
+            "<h2 class=\"autonumber autonumber-1 autonumber-N\">^baz</h2>",
             bot.htmlWithSelection(),
-            "applied 1aiai to p, and it became an h1"
+            "applied 1aiai to p, and it became an h2 at the right level"
         );
       });
-    },
+    }
   });
 })();

--- a/tests/structuredheadings/setnumberingstyle.js
+++ b/tests/structuredheadings/setnumberingstyle.js
@@ -45,7 +45,9 @@
     },
     "apply numbering style to multiple non-autonumbered h1 using a partial selection": function () {
       var bot = this.editorBot;
-      bot.setHtmlWithSelection("[<h1>foo</h1><h1>b]ar</h1>");
+      var initialHtmlWithSelection = "[<h1>foo</h1><h1>b]ar</h1>";
+      var initialHtmlWithoutSelection = "<h1>foo</h1><h1>bar</h1>";
+      bot.setHtmlWithSelection(initialHtmlWithSelection);
 
       bot.combo(comboName, function (combo) {
         combo.onClick("1. a. i. a. i.");
@@ -54,6 +56,15 @@
             "<h1 class=\"autonumber autonumber-0 autonumber-N\">bar</h1>",
             bot.getData(),
             "applied 1aiai to both h1"
+        );
+
+        bot.execCommand("undo");
+
+        // weird phantom p bug
+        assert.areSame(
+          initialHtmlWithoutSelection,
+          bot.getData(),
+          "undid the numbering style"
         );
       });
     },
@@ -192,6 +203,6 @@
           "undid the numbering style"
         );
       });
-    },
+    }
   });
 })();

--- a/tests/structuredheadings/setnumberingstyle.js
+++ b/tests/structuredheadings/setnumberingstyle.js
@@ -167,6 +167,31 @@
           "undid the numbering style"
         );
       });
-    }
+    },
+    "apply numbering style to a strong tag, so it becomes a heading": function () {
+      var bot = this.editorBot;
+      var initialHtmlWithSelection = "<p><strong>^foo</strong></p>";
+      bot.setHtmlWithSelection(initialHtmlWithSelection);
+
+      bot.combo(comboName, function (combo) {
+        combo.onClick("1. a. i. a. i.");
+
+        // yes, the strong tag doesn't get cleared even in the original behaviour
+        // the heading style trumps it though
+        assert.areSame(
+            "<h1 class=\"autonumber autonumber-0 autonumber-N\"><strong>^foo</strong></h1>",
+            bot.htmlWithSelection(),
+            "applied 1aiai to p, and it became an h1"
+        );
+
+        bot.execCommand("undo");
+
+        assert.areSame(
+          initialHtmlWithSelection,
+          bot.htmlWithSelection(),
+          "undid the numbering style"
+        );
+      });
+    },
   });
 })();

--- a/tests/structuredheadings/setnumberingstyle.js
+++ b/tests/structuredheadings/setnumberingstyle.js
@@ -123,7 +123,8 @@
     },
     "apply numbering style to a paragraph, so it becomes a heading": function () {
       var bot = this.editorBot;
-      bot.setHtmlWithSelection("<p>^foo</p>");
+      var initialHtmlWithSelection = "<p>^foo</p>";
+      bot.setHtmlWithSelection(initialHtmlWithSelection);
 
       bot.combo(comboName, function (combo) {
         combo.onClick("1. a. i. a. i.");
@@ -132,11 +133,20 @@
             bot.htmlWithSelection(),
             "applied 1aiai to p, and it became an h1"
         );
+
+        bot.execCommand("undo");
+
+        assert.areSame(
+          initialHtmlWithSelection,
+          bot.htmlWithSelection(),
+          "undid the numbering style"
+        );
       });
     },
     "match the heading level when going paragraph -> numbered": function () {
       var bot = this.editorBot;
-      bot.setHtmlWithSelection("<h2>foo</h2><p>bar</p><p>^baz</p>");
+      var initialHtmlWithSelection = "<h2>foo</h2><p>bar</p><p>^baz</p>";
+      bot.setHtmlWithSelection(initialHtmlWithSelection);
 
       bot.combo(comboName, function (combo) {
         combo.onClick("1. a. i. a. i.");
@@ -147,6 +157,14 @@
             "<h2 class=\"autonumber autonumber-1 autonumber-a\">^baz</h2>",
             bot.htmlWithSelection(),
             "applied 1aiai to p, and it became an h2 at the right level"
+        );
+
+        bot.execCommand("undo");
+
+        assert.areSame(
+          initialHtmlWithSelection,
+          bot.htmlWithSelection(),
+          "undid the numbering style"
         );
       });
     }

--- a/tests/structuredheadings/setnumberingstyle.js
+++ b/tests/structuredheadings/setnumberingstyle.js
@@ -134,5 +134,22 @@
         );
       });
     },
+    "match the heading level when going paragraph -> numbered": function () {
+      var bot = this.editorBot;
+      bot.setHtmlWithSelection("<h2>foo</h2><p>bar</p><p>^baz</p>");
+
+      bot.combo(comboName, function (combo) {
+        combo.onClick("1. a. i. a. i.");
+        // this is an interesting case.  should the prior unnumbered heading be numbered?
+        // probably not.
+        assert.areSame(
+            "<h2>foo</h2>" +
+            "<p>bar</p>" +
+            "<h2 class=\"autonumber autonumber-0 autonumber-N\">^baz</h2>",
+            bot.htmlWithSelection(),
+            "applied 1aiai to p, and it became an h1"
+        );
+      });
+    },
   });
 })();


### PR DESCRIPTION
When a non-heading is selected via collapsed selection, convert it into the appropriate heading and apply the selected numbering 