### PR TITLE
Detect current numbering scheme on load

### DIFF
--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -251,7 +251,7 @@
           var classForPresetAtLevel = editor.config.autonumberStyles[candidatePresetName][i];
 
           if (!sampleHeading.hasClass(classForPresetAtLevel)) {
-            presetsToRemove.push(presetsToRemove);
+            presetsToRemove.push(classForPresetAtLevel);
           }
         }
 

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -302,7 +302,7 @@
       setupCommands(editor);
       setupStyles(editor);
 
-      editor.on("instanceReady", function () {
+      editor.on("dataReady", function () {
         self.currentScheme = self.detectScheme();
       });
 

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -274,7 +274,7 @@
       }
 
       // remove all presets that did not match, from the total set of numbering schemes
-      candidateSchemes = candidateSchemes.filter(function (presetName) {
+      candidateSchemes = candidateSchemes.filter(function isDisqualified(presetName) {
         return disqualifiedSchemes.indexOf(presetName) === -1;
       });
 

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -224,7 +224,7 @@
     getCurrentPreset: function () {
       var editor = this.editor;
       // TODO validate some assumptions about ordering
-      var candidatePresets = editor.config.autonumberStyles.keys();
+      var candidatePresets = Object.keys(editor.config.autonumberStyles);
       var headingLevels = editor.config.numberedElements;
       var baseClass = editor.config.autonumberBaseClass;
       var sampleHeading;

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -251,7 +251,7 @@
           var classForPresetAtLevel = editor.config.autonumberStyles[candidatePresetName][i];
 
           if (!sampleHeading.hasClass(classForPresetAtLevel)) {
-            presetsToRemove.push(classForPresetAtLevel);
+            presetsToRemove.push(candidatePresetName);
           }
         }
 

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -302,6 +302,10 @@
       setupCommands(editor);
       setupStyles(editor);
 
+      editor.on("instanceReady", function () {
+        self.currentScheme = self.detectScheme();
+      });
+
       //Format Dropdown
       editor.ui.addRichCombo("NumFormats", {
         label: "Formats",

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -227,12 +227,12 @@
 
   CKEDITOR.plugins.add("structuredheadings", {
     currentScheme: "1.1.1.1.1.",
-    getUnmatchingSchemes: function (sampleHeading, candidateSchemes) {
+    getUnmatchingSchemes: function (sampleHeading, candidateSchemes, level) {
       var editor = this.editor;
       var disqualifiedSchemes = [];
       for (var j = 0; j < candidateSchemes.length; j++) {
         var candidateSchemeName = candidateSchemes[j];
-        var classForPresetAtLevel = editor.config.autonumberStyles[candidateSchemeName][i];
+        var classForPresetAtLevel = editor.config.autonumberStyles[candidateSchemeName][level];
 
         if (!sampleHeading.hasClass(classForPresetAtLevel)) {
           disqualifiedSchemes.push(candidateSchemeName);
@@ -263,7 +263,7 @@
         }
 
         disqualifiedSchemes = disqualifiedSchemes.concat(
-          this.getUnmatchingSchemes(sampleHeading, candidateSchemes)
+          this.getUnmatchingSchemes(sampleHeading, candidateSchemes, i)
         );
       }
 

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -273,6 +273,12 @@
         );
       }
 
+      if (disqualifiedSchemes.length === 0) {
+        // no headings, or the headings didn't actually tell us anything about
+        // the current scheme
+        return this.currentScheme;
+      }
+
       // remove all presets that did not match, from the total set of numbering schemes
       candidateSchemes = candidateSchemes.filter(function (presetName) {
         return disqualifiedSchemes.indexOf(presetName) === -1;

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -273,26 +273,20 @@
         );
       }
 
-      if (disqualifiedSchemes.length === 0) {
-        // no headings, or the headings didn't actually tell us anything about
-        // the current scheme
-        return this.currentScheme;
-      }
-
       // remove all presets that did not match, from the total set of numbering schemes
       candidateSchemes = candidateSchemes.filter(function (presetName) {
         return disqualifiedSchemes.indexOf(presetName) === -1;
       });
 
-      // return one of whatever returns, this should never happen with the default
-      if (candidateSchemes.length > 0) {
-        // just return the first, if there is more than 1, it means
-        // the headings are configured in a way that the scheme was left ambiguous
-        return candidateSchemes[0];
-      } else {
+      // we eliminated everything, or didn't eliminate anything
+      if (candidateSchemes.length === 0 || disqualifiedSchemes.length === 0) {
         // return whatever was already set, for consistency
         // this also handles the 'null' css scheme case since it's the default
         return this.currentScheme;
+      } else {
+        // just return the first, if there is more than 1, it means
+        // the headings are configured in a way that the scheme was left ambiguous
+        return candidateSchemes[0];
       }
 
     },

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -227,7 +227,10 @@
 
   CKEDITOR.plugins.add("structuredheadings", {
     currentScheme: "1.1.1.1.1.",
-    getUnmatchingSchemes: function (sampleHeading, candidateSchemes, level) {
+    getNonMatchingSchemes: function (sampleHeading, candidateSchemes, level) {
+      // giving a heading, possible numbering schemes, and the level index
+      // (which can technically be recalculated based on configs, but oh well)
+      // return the schemes that do not match the heading and its css classes
       var editor = this.editor;
       var disqualifiedSchemes = [];
       for (var j = 0; j < candidateSchemes.length; j++) {
@@ -242,8 +245,11 @@
       return disqualifiedSchemes;
     },
     getCurrentScheme: function () {
+      // check the document's headings,
+      // eliminating numbering schemes that do not match,
+      // until we are left with a matching scheme, or just keep the current one
+      // (inconsistencies will be fixed when the numbering scheme is next applied)
       var editor = this.editor;
-      // TODO validate some assumptions about ordering
       var candidateSchemes = editor.config.autonumberStylesWithClasses;
       var headingLevels = editor.config.numberedElements;
       var disqualifiedSchemes = [];
@@ -263,12 +269,11 @@
         }
 
         disqualifiedSchemes = disqualifiedSchemes.concat(
-          this.getUnmatchingSchemes(sampleHeading, candidateSchemes, i)
+          this.getNonMatchingSchemes(sampleHeading, candidateSchemes, i)
         );
       }
 
-      // remove all presets that did not match
-
+      // remove all presets that did not match, from the total set of numbering schemes
       candidateSchemes = candidateSchemes.filter(function (presetName) {
         return disqualifiedSchemes.indexOf(presetName) === -1;
       });
@@ -280,6 +285,7 @@
         return candidateSchemes[0];
       } else {
         // return whatever was already set, for consistency
+        // this also handles the 'null' css scheme case since it's the default
         return this.currentScheme;
       }
 

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -244,7 +244,7 @@
 
       return disqualifiedSchemes;
     },
-    getCurrentScheme: function () {
+    detectScheme: function () {
       // check the document's headings,
       // eliminating numbering schemes that do not match,
       // until we are left with a matching scheme, or just keep the current one

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -247,12 +247,21 @@
           }
         }
 
-        // remove all presets that failed
+        // remove all presets that did not match
+
+        candidatePresets = candidatePresets.filter(function(presetName) {
+          return presetsToRemove.indexOf(presetName) === -1;
+        });
 
         // check if only 1 remains, return it
+
+        if (candidatePresets.length === 1) {
+          return candidatePresets[0];
+        }
       }
 
       // return one of whatever returns, this should never happen with the default
+      return candidatePresets[0];
 
     },
     init: function (editor) {

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -227,12 +227,26 @@
 
   CKEDITOR.plugins.add("structuredheadings", {
     currentScheme: "1.1.1.1.1.",
+    getUnmatchingSchemes: function (sampleHeading, candidateSchemes) {
+      var editor = this.editor;
+      var disqualifiedSchemes = [];
+      for (var j = 0; j < candidateSchemes.length; j++) {
+        var candidateSchemeName = candidateSchemes[j];
+        var classForPresetAtLevel = editor.config.autonumberStyles[candidateSchemeName][i];
+
+        if (!sampleHeading.hasClass(classForPresetAtLevel)) {
+          disqualifiedSchemes.push(candidateSchemeName);
+        }
+      }
+
+      return disqualifiedSchemes;
+    },
     getCurrentScheme: function () {
       var editor = this.editor;
       // TODO validate some assumptions about ordering
       var candidateSchemes = editor.config.autonumberStylesWithClasses;
       var headingLevels = editor.config.numberedElements;
-      var disqualifiedPresets = [];
+      var disqualifiedSchemes = [];
 
       for (var i = 0; i < headingLevels.length; i++) {
         var autonumberedHeadingSelector = headingLevels[i] +
@@ -248,22 +262,15 @@
           continue;
         }
 
-        // check all schemes for a match
-
-        for (var j = 0; j < candidateSchemes.length; j++) {
-          var candidateSchemeName = candidateSchemes[j];
-          var classForPresetAtLevel = editor.config.autonumberStyles[candidateSchemeName][i];
-
-          if (!sampleHeading.hasClass(classForPresetAtLevel)) {
-            disqualifiedPresets.push(candidateSchemeName);
-          }
-        }
+        disqualifiedSchemes = disqualifiedSchemes.concat(
+          this.getUnmatchingSchemes(sampleHeading, candidateSchemes)
+        );
       }
 
       // remove all presets that did not match
 
       candidateSchemes = candidateSchemes.filter(function (presetName) {
-        return disqualifiedPresets.indexOf(presetName) === -1;
+        return disqualifiedSchemes.indexOf(presetName) === -1;
       });
 
       // return one of whatever returns, this should never happen with the default

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -235,17 +235,20 @@
       var disqualifiedPresets = [];
 
       for (var i = 0; i < headingLevels.length; i++) {
-        // if all our other updates work properly it shouldn't matter which one we pick
+        var autonumberedHeadingSelector = headingLevels[i] +
+          "." +
+          editor.config.autonumberBaseClass;
+
+        // it shouldn't matter which one we pick
         // so long as its autonumbered
-        var autonumberedHeadingSelector = headingLevels[i] + "." + editor.config.autonumberBaseClass;
         var sampleHeading = editor.document.findOne(autonumberedHeadingSelector);
 
-        // no headings at current level
+        // no headings at current level are autonumbered
         if (!sampleHeading) {
           continue;
         }
 
-        // check all presets for a match
+        // check all schemes for a match
 
         for (var j = 0; j < candidateSchemes.length; j++) {
           var candidateSchemeName = candidateSchemes[j];
@@ -264,9 +267,12 @@
       });
 
       // return one of whatever returns, this should never happen with the default
-      if (candidateSchemes.length) {
+      if (candidateSchemes.length > 0) {
+        // just return the first, if there is more than 1, it means
+        // the headings are configured in a way that the scheme was left ambiguous
         return candidateSchemes[0];
       } else {
+        // return whatever was already set, for consistency
         return this.currentScheme;
       }
 

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -221,8 +221,43 @@
 
   CKEDITOR.plugins.add("structuredheadings", {
     currentPreset: "1.1.1.1.1.",
+    getCurrentPreset: function () {
+      var editor = this.editor;
+      // TODO validate some assumptions about ordering
+      var candidatePresets = editor.config.autonumberStyles.keys();
+      var headingLevels = editor.config.numberedElements;
+      var baseClass = editor.config.autonumberBaseClass;
+      var sampleHeading;
+
+      for (var i = 0; i < headingLevels.length; i++) {
+        // if all our other updates work properly it shouldn't matter which one we pick
+        // so long as its autonumbered
+        var autonumberedHeadingSelector = headingLevels[i] + "." + baseClass;
+        var presetsToRemove = [];
+        sampleHeading = editor.document.findOne(autonumberedHeadingSelector);
+
+        // check all presets for a match
+
+        for (var j = 0; j < candidatePresets.length; j++) {
+          var candidatePresetName = candidatePresets[j];
+          var classForPresetAtLevel = editor.config.autonumberStyles[candidatePresetName][i];
+
+          if (!sampleHeading.hasClass(classForPresetAtLevel)) {
+            presetsToRemove.push(presetsToRemove);
+          }
+        }
+
+        // remove all presets that failed
+
+        // check if only 1 remains, return it
+      }
+
+      // return one of whatever returns, this should never happen with the default
+
+    },
     init: function (editor) {
       var self = this;
+      this.editor = editor;
       var TAB_KEY_CODE = 9;
 
       editor.config.autonumberStyleImgPath = this.path + "dialogs/img";

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -240,6 +240,10 @@
 
         for (var j = 0; j < candidatePresets.length; j++) {
           var candidatePresetName = candidatePresets[j];
+          if (!editor.config.autonumberStyles[candidatePresetName][i]) {
+            // skip the default classless case
+            continue;
+          }
           var classForPresetAtLevel = editor.config.autonumberStyles[candidatePresetName][i];
 
           if (!sampleHeading.hasClass(classForPresetAtLevel)) {

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -227,20 +227,24 @@
       var candidatePresets = Object.keys(editor.config.autonumberStyles);
       var headingLevels = editor.config.numberedElements;
       var baseClass = editor.config.autonumberBaseClass;
-      var sampleHeading;
 
       for (var i = 0; i < headingLevels.length; i++) {
         // if all our other updates work properly it shouldn't matter which one we pick
         // so long as its autonumbered
         var autonumberedHeadingSelector = headingLevels[i] + "." + baseClass;
         var presetsToRemove = [];
-        sampleHeading = editor.document.findOne(autonumberedHeadingSelector);
+        var sampleHeading = editor.document.findOne(autonumberedHeadingSelector);
+
+        // no headings at current level
+        if (!sampleHeading) {
+          continue;
+        }
 
         // check all presets for a match
 
         for (var j = 0; j < candidatePresets.length; j++) {
           var candidatePresetName = candidatePresets[j];
-          if (!editor.config.autonumberStyles[candidatePresetName][i]) {
+          if (!editor.config.autonumberStyles[candidatePresetName]) {
             // skip the default classless case
             continue;
           }
@@ -253,7 +257,7 @@
 
         // remove all presets that did not match
 
-        candidatePresets = candidatePresets.filter(function(presetName) {
+        candidatePresets = candidatePresets.filter(function (presetName) {
           return presetsToRemove.indexOf(presetName) === -1;
         });
 

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -230,7 +230,7 @@
     getCurrentScheme: function () {
       var editor = this.editor;
       // TODO validate some assumptions about ordering
-      var candidatePresets = editor.config.autonumberStylesWithClasses;
+      var candidateSchemes = editor.config.autonumberStylesWithClasses;
       var headingLevels = editor.config.numberedElements;
       var disqualifiedPresets = [];
 
@@ -247,25 +247,25 @@
 
         // check all presets for a match
 
-        for (var j = 0; j < candidatePresets.length; j++) {
-          var candidatePresetName = candidatePresets[j];
-          var classForPresetAtLevel = editor.config.autonumberStyles[candidatePresetName][i];
+        for (var j = 0; j < candidateSchemes.length; j++) {
+          var candidateSchemeName = candidateSchemes[j];
+          var classForPresetAtLevel = editor.config.autonumberStyles[candidateSchemeName][i];
 
           if (!sampleHeading.hasClass(classForPresetAtLevel)) {
-            disqualifiedPresets.push(candidatePresetName);
+            disqualifiedPresets.push(candidateSchemeName);
           }
         }
       }
 
       // remove all presets that did not match
 
-      candidatePresets = candidatePresets.filter(function (presetName) {
+      candidateSchemes = candidateSchemes.filter(function (presetName) {
         return disqualifiedPresets.indexOf(presetName) === -1;
       });
 
       // return one of whatever returns, this should never happen with the default
-      if (candidatePresets.length) {
-        return candidatePresets[0];
+      if (candidateSchemes.length) {
+        return candidateSchemes[0];
       } else {
         return this.currentScheme;
       }

--- a/tests/structuredheadings/formatcombo.js
+++ b/tests/structuredheadings/formatcombo.js
@@ -19,7 +19,7 @@
 
     tearDown: function () {
       var editor = this.editorBot.editor;
-      editor.plugins.structuredheadings.currentScheme = null;
+      editor.plugins.structuredheadings.currentScheme = "1.1.1.1.1.";
     },
 
     "if no headings in document, the new heading is autonumbered": function () {

--- a/tests/structuredheadings/presetdiscovery.js
+++ b/tests/structuredheadings/presetdiscovery.js
@@ -1,0 +1,25 @@
+/* eslint-disable */
+/* bender-tags: editor,unit */
+/* bender-ckeditor-plugins: wysiwygarea,structuredheadings,toolbar,basicstyles,dialog,richcombo,undo */
+/* eslint-enable */
+
+// Clean up all instances been created on the page.
+(function () {
+
+  bender.editor = {
+    allowedForTests: "h1; h2; h3; h4; h5; p"
+  };
+
+  bender.test({
+    setUp: function () {
+      //Anything to be run before each test if needed
+    },
+
+    tearDown: function () {
+      // reset the plugin between tests
+      var editor = this.editorBot.editor;
+      editor.plugins.structuredheadings.currentPreset = null;
+    }
+
+  });
+})();

--- a/tests/structuredheadings/presetdiscovery.js
+++ b/tests/structuredheadings/presetdiscovery.js
@@ -51,6 +51,19 @@
         "1.1.1.1.1.",
         getDetectedPreset(editor)
       );
+    },
+
+    "can detect based off of one level": function () {
+      var bot = this.editorBot;
+      var editor = bot.editor;
+      bot.setHtmlWithSelection(
+        "<h1 class=\"autonumber autonumber-0 autonumber-N\">^foo</h1>"
+      );
+
+      assert.areEqual(
+        "1. a. i. a. i.",
+        getDetectedPreset(editor)
+      );
     }
 
 

--- a/tests/structuredheadings/presetdiscovery.js
+++ b/tests/structuredheadings/presetdiscovery.js
@@ -37,6 +37,20 @@
         "1.1.1.1.1.",
         getDetectedPreset(editor)
       );
+    },
+
+    "invalid combos return numbered": function () {
+      var bot = this.editorBot;
+      var editor = bot.editor;
+      bot.setHtmlWithSelection(
+        "<h1 class=\"autonumber autonumber-0 autonumber-a\">^foo</h1>" +
+        "<h2 class=\"autonumber autonumber-1 autonumber-N\">bar</h2>"
+      );
+
+      assert.areEqual(
+        "1.1.1.1.1.",
+        getDetectedPreset(editor)
+      );
     }
 
 

--- a/tests/structuredheadings/presetdiscovery.js
+++ b/tests/structuredheadings/presetdiscovery.js
@@ -10,6 +10,10 @@
     allowedForTests: "h1; h2; h3; h4; h5; p"
   };
 
+  function getDetectedPreset(editor) {
+    return editor.plugins.structuredheadings.getCurrentPreset();
+  };
+
   bender.test({
     setUp: function () {
       //Anything to be run before each test if needed
@@ -19,7 +23,22 @@
       // reset the plugin between tests
       var editor = this.editorBot.editor;
       editor.plugins.structuredheadings.currentPreset = null;
+    },
+
+    "default is numbered": function () {
+      var bot = this.editorBot;
+      var editor = bot.editor;
+      bot.setHtmlWithSelection(
+        "<h1 class=\"autonumber autonumber-0\">^foo</h1>" +
+        "<h2 class=\"autonumber autonumber-1\">bar</h2>"
+      );
+
+      assert.areEqual(
+        "1.1.1.1.1.",
+        getDetectedPreset(editor)
+      );
     }
+
 
   });
 })();

--- a/tests/structuredheadings/schemediscovery.js
+++ b/tests/structuredheadings/schemediscovery.js
@@ -76,7 +76,7 @@
 
       bot.setHtmlWithSelection(
         "<h1 class=\"autonumber autonumber-0\">^foo</h1>" +
-        "<h2 class=\"autonumber autonumber-1\">^foo</h2>"
+        "<h2 class=\"autonumber autonumber-1\">foo</h2>"
       );
 
       assert.areEqual(
@@ -92,7 +92,7 @@
       // A.A. is not a valid default
       bot.setHtmlWithSelection(
         "<h1 class=\"autonumber autonumber-0 autonumber-A\">^foo</h1>" +
-        "<h2 class=\"autonumber autonumber-1 autonumber-A\">^foo</h2>"
+        "<h2 class=\"autonumber autonumber-1 autonumber-A\">foo</h2>"
       );
 
       assert.areEqual(
@@ -104,15 +104,30 @@
     "autodetect will detect a schemed document": function () {
       var bot = this.editorBot;
       var editor = bot.editor;
-      bot.setHtmlWithSelection(
-        "<h1 class=\"autonumber autonumber-0 autonumber-N\">^foo</h1>" +
-        "<h2 class=\"autonumber autonumber-1 autonumber-a\">^foo</h2>"
+
+      var listener = editor.on(
+        "dataReady",
+        function () {
+          listener.removeListener();
+          resume(function() {
+            assert.areEqual(
+              "1. a. i. a. i.",
+              getCurrentScheme(editor)
+            );
+          });
+        },
+        null,
+        null,
+        9999
       );
 
-      assert.areEqual(
-        "1. a. i. a. i.",
-        getCurrentScheme(editor)
+      // this is quite WTF, somehow setHtmlWithSelection doesn't fire dataReady events
+      bot.editor.setData(
+        "<h1 class=\"autonumber autonumber-0 autonumber-N\">^foo</h1>" +
+        "<h2 class=\"autonumber autonumber-1 autonumber-a\">foo</h2>"
       );
+      wait();
+
     }
 
   });

--- a/tests/structuredheadings/schemediscovery.js
+++ b/tests/structuredheadings/schemediscovery.js
@@ -93,8 +93,9 @@
         VERY_LAST_PRIORITY
       );
 
+      // cannot use bot.setHtmlWithSelection, it does not fire dataReady events
       editor.setData(
-        "<h1 class=\"autonumber autonumber-0\">^foo</h1>" +
+        "<h1 class=\"autonumber autonumber-0\">foo</h1>" +
         "<h2 class=\"autonumber autonumber-1\">foo</h2>"
       );
 
@@ -121,8 +122,9 @@
       );
 
       // A.A. is not a valid default
+      // cannot use bot.setHtmlWithSelection, it does not fire dataReady events
       editor.setData(
-        "<h1 class=\"autonumber autonumber-0 autonumber-A\">^foo</h1>" +
+        "<h1 class=\"autonumber autonumber-0 autonumber-A\">foo</h1>" +
         "<h2 class=\"autonumber autonumber-1 autonumber-A\">foo</h2>"
       );
 
@@ -149,9 +151,9 @@
         VERY_LAST_PRIORITY
       );
 
-      // this is quite WTF, somehow setHtmlWithSelection doesn't fire dataReady events
+      // cannot use bot.setHtmlWithSelection, it does not fire dataReady events
       editor.setData(
-        "<h1 class=\"autonumber autonumber-0 autonumber-N\">^foo</h1>" +
+        "<h1 class=\"autonumber autonumber-0 autonumber-N\">foo</h1>" +
         "<h2 class=\"autonumber autonumber-1 autonumber-a\">foo</h2>"
       );
       wait();

--- a/tests/structuredheadings/schemediscovery.js
+++ b/tests/structuredheadings/schemediscovery.js
@@ -22,7 +22,7 @@
     tearDown: function () {
       // reset the plugin between tests
       var editor = this.editorBot.editor;
-      editor.plugins.structuredheadings.currentScheme = null;
+      editor.plugins.structuredheadings.currentScheme = "1.1.1.1.1.";
     },
 
     "default is numbered": function () {

--- a/tests/structuredheadings/schemediscovery.js
+++ b/tests/structuredheadings/schemediscovery.js
@@ -74,8 +74,22 @@
 
     },
 
-    "autodetect will detect a schemed document": function() {
+    "autodetect falls to default if nothing matches": function () {
 
+    },
+
+    "autodetect will detect a schemed document": function () {
+      var bot = this.editorBot;
+      var editor = bot.editor;
+      bot.setHtmlWithSelection(
+        "<h1 class=\"autonumber autonumber-0 autonumber-N\">^foo</h1>" +
+        "<h2 class=\"autonumber autonumber-1 autonumber-a\">^foo</h2>"
+      );
+
+      assert.areEqual(
+        "1. a. i. a. i.",
+        getCurrentScheme(editor)
+      );
     }
 
   });

--- a/tests/structuredheadings/schemediscovery.js
+++ b/tests/structuredheadings/schemediscovery.js
@@ -1,3 +1,4 @@
+/* global wait, resume */
 /* eslint-disable */
 /* bender-tags: editor,unit */
 /* bender-ckeditor-plugins: wysiwygarea,structuredheadings,toolbar,basicstyles,dialog,richcombo,undo */

--- a/tests/structuredheadings/schemediscovery.js
+++ b/tests/structuredheadings/schemediscovery.js
@@ -11,7 +11,11 @@
   };
 
   var detectScheme = function (editor) {
-    return editor.plugins.structuredheadings.getCurrentScheme();
+    return editor.plugins.structuredheadings.detectScheme();
+  };
+
+  var getCurrentScheme = function (editor) {
+    return editor.plugins.structuredheadings.currentScheme;
   };
 
   bender.test({

--- a/tests/structuredheadings/schemediscovery.js
+++ b/tests/structuredheadings/schemediscovery.js
@@ -10,7 +10,7 @@
     allowedForTests: "h1; h2; h3; h4; h5; p"
   };
 
-  function getDetectedScheme(editor) {
+  var getDetectedScheme = function (editor) {
     return editor.plugins.structuredheadings.getCurrentScheme();
   };
 

--- a/tests/structuredheadings/schemediscovery.js
+++ b/tests/structuredheadings/schemediscovery.js
@@ -64,8 +64,15 @@
         "1. a. i. a. i.",
         detectScheme(editor)
       );
-    }
+    },
 
+    "autodetect will detect a default scheme document": function () {
+
+    },
+
+    "autodetect will detect a schemed document": function() {
+
+    }
 
   });
 })();

--- a/tests/structuredheadings/schemediscovery.js
+++ b/tests/structuredheadings/schemediscovery.js
@@ -10,7 +10,7 @@
     allowedForTests: "h1; h2; h3; h4; h5; p"
   };
 
-  var getDetectedScheme = function (editor) {
+  var detectScheme = function (editor) {
     return editor.plugins.structuredheadings.getCurrentScheme();
   };
 
@@ -35,7 +35,7 @@
 
       assert.areEqual(
         "1.1.1.1.1.",
-        getDetectedScheme(editor)
+        detectScheme(editor)
       );
     },
 
@@ -49,7 +49,7 @@
 
       assert.areEqual(
         "1.1.1.1.1.",
-        getDetectedScheme(editor)
+        detectScheme(editor)
       );
     },
 
@@ -62,7 +62,7 @@
 
       assert.areEqual(
         "1. a. i. a. i.",
-        getDetectedScheme(editor)
+        detectScheme(editor)
       );
     }
 

--- a/tests/structuredheadings/schemediscovery.js
+++ b/tests/structuredheadings/schemediscovery.js
@@ -11,6 +11,8 @@
     allowedForTests: "h1; h2; h3; h4; h5; p"
   };
 
+  var VERY_LAST_PRIORITY = 9999;
+
   var detectScheme = function (editor) {
     return editor.plugins.structuredheadings.detectScheme();
   };
@@ -75,31 +77,56 @@
       var bot = this.editorBot;
       var editor = bot.editor;
 
-      bot.setHtmlWithSelection(
+      var listener = editor.on(
+        "dataReady",
+        function () {
+          listener.removeListener();
+          resume(function () {
+            assert.areEqual(
+              "1.1.1.1.1.",
+              getCurrentScheme(editor)
+            );
+          });
+        },
+        null,
+        null,
+        VERY_LAST_PRIORITY
+      );
+
+      editor.setData(
         "<h1 class=\"autonumber autonumber-0\">^foo</h1>" +
         "<h2 class=\"autonumber autonumber-1\">foo</h2>"
       );
 
-      assert.areEqual(
-        "1.1.1.1.1.",
-        getCurrentScheme(editor)
-      );
+      wait();
     },
 
     "autodetect falls to default if nothing matches": function () {
       var bot = this.editorBot;
       var editor = bot.editor;
+      var listener = editor.on(
+        "dataReady",
+        function () {
+          listener.removeListener();
+          resume(function () {
+            assert.areEqual(
+              "1.1.1.1.1.",
+              getCurrentScheme(editor)
+            );
+          });
+        },
+        null,
+        null,
+        VERY_LAST_PRIORITY
+      );
 
       // A.A. is not a valid default
-      bot.setHtmlWithSelection(
+      editor.setData(
         "<h1 class=\"autonumber autonumber-0 autonumber-A\">^foo</h1>" +
         "<h2 class=\"autonumber autonumber-1 autonumber-A\">foo</h2>"
       );
 
-      assert.areEqual(
-        "1.1.1.1.1.",
-        getCurrentScheme(editor)
-      );
+      wait();
     },
 
     "autodetect will detect a schemed document": function () {
@@ -110,7 +137,7 @@
         "dataReady",
         function () {
           listener.removeListener();
-          resume(function() {
+          resume(function () {
             assert.areEqual(
               "1. a. i. a. i.",
               getCurrentScheme(editor)
@@ -119,11 +146,11 @@
         },
         null,
         null,
-        9999
+        VERY_LAST_PRIORITY
       );
 
       // this is quite WTF, somehow setHtmlWithSelection doesn't fire dataReady events
-      bot.editor.setData(
+      editor.setData(
         "<h1 class=\"autonumber autonumber-0 autonumber-N\">^foo</h1>" +
         "<h2 class=\"autonumber autonumber-1 autonumber-a\">foo</h2>"
       );

--- a/tests/structuredheadings/schemediscovery.js
+++ b/tests/structuredheadings/schemediscovery.js
@@ -10,8 +10,8 @@
     allowedForTests: "h1; h2; h3; h4; h5; p"
   };
 
-  function getDetectedPreset(editor) {
-    return editor.plugins.structuredheadings.getCurrentPreset();
+  function getDetectedScheme(editor) {
+    return editor.plugins.structuredheadings.getCurrentScheme();
   };
 
   bender.test({
@@ -22,7 +22,7 @@
     tearDown: function () {
       // reset the plugin between tests
       var editor = this.editorBot.editor;
-      editor.plugins.structuredheadings.currentPreset = null;
+      editor.plugins.structuredheadings.currentScheme = null;
     },
 
     "default is numbered": function () {
@@ -35,7 +35,7 @@
 
       assert.areEqual(
         "1.1.1.1.1.",
-        getDetectedPreset(editor)
+        getDetectedScheme(editor)
       );
     },
 
@@ -49,7 +49,7 @@
 
       assert.areEqual(
         "1.1.1.1.1.",
-        getDetectedPreset(editor)
+        getDetectedScheme(editor)
       );
     },
 
@@ -62,7 +62,7 @@
 
       assert.areEqual(
         "1. a. i. a. i.",
-        getDetectedPreset(editor)
+        getDetectedScheme(editor)
       );
     }
 

--- a/tests/structuredheadings/schemediscovery.js
+++ b/tests/structuredheadings/schemediscovery.js
@@ -71,11 +71,34 @@
     },
 
     "autodetect will detect a default scheme document": function () {
+      var bot = this.editorBot;
+      var editor = bot.editor;
 
+      bot.setHtmlWithSelection(
+        "<h1 class=\"autonumber autonumber-0\">^foo</h1>" +
+        "<h2 class=\"autonumber autonumber-1\">^foo</h2>"
+      );
+
+      assert.areEqual(
+        "1.1.1.1.1.",
+        getCurrentScheme(editor)
+      );
     },
 
     "autodetect falls to default if nothing matches": function () {
+      var bot = this.editorBot;
+      var editor = bot.editor;
 
+      // A.A. is not a valid default
+      bot.setHtmlWithSelection(
+        "<h1 class=\"autonumber autonumber-0 autonumber-A\">^foo</h1>" +
+        "<h2 class=\"autonumber autonumber-1 autonumber-A\">^foo</h2>"
+      );
+
+      assert.areEqual(
+        "1.1.1.1.1.",
+        getCurrentScheme(editor)
+      );
     },
 
     "autodetect will detect a schemed document": function () {


### PR DESCRIPTION
When the document content is replaced, look at the headings, and figure out which numbering scheme best fits the document.  

This is mainly for loading the doc, but also works for if someone replaces all the content via the source panel.  

fixes #67