### PR TITLE
Re-allow the policystat behaviour where we allowed same styles in nested list

### DIFF
--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -813,9 +813,36 @@
         }
       },
       applyListStyle: {
+        getCutOffIndex: function (elements, tagNames) {
+          // given an array of elements and an array of tag names to stop on,
+          // returns the earliest index of any of the tag names, or -1
+          var minIndexes = {};
+          var cutOffIndexes = [];
+
+          for (var i = elements.length - 1; i >= 0; --i) {
+            minIndexes[elements[i].getName()] = i;
+          }
+
+          tagNames.forEach(function(tagName) {
+            if (minIndexes[tagName] !== undefined) {
+              cutOffIndexes.push(minIndexes[tagName]);
+            }
+          });
+
+          if (cutOffIndexes.length !== 0) {
+            return Math.min.apply(null, cutOffIndexes);
+          } else {
+            return -1;
+          }
+        },
         exec: function(editor, style) {
           // see https://github.com/ckeditor/ckeditor-dev/blob/major/plugins/stylescombo/plugin.js#L110
           var elementPath = editor.elementPath();
+          var cutoff = this.getCutOffIndex(elementPath.elements, ["ol", "ul"]);
+          if (cutoff !== -1) {
+            // trim the path to only the list item and parent.
+            elementPath.elements = elementPath.elements.slice(0, 1 + cutoff);
+          }
           editor[style.checkActive(elementPath, editor) ? "removeStyle" : "applyStyle"](style);
         }
       }

--- a/tests/structuredheadings/setnumberingstyletolist.js
+++ b/tests/structuredheadings/setnumberingstyletolist.js
@@ -132,6 +132,33 @@
         afterHtml: afterHtmlWithSelection
       };
       this.assertComboBeforeAfter(opts);
+    },
+    "applying a simple style deeply": function() {
+      var comboItem = "List: A. B. C.";
+      var beforeHtmlWithSelection = "<ol class=\"list-upper-alpha\"><li>foo</li>" +
+        "<li><ol><li>^bar</li><ol></li></ol>";
+      var afterHtmlWithSelection = "<ol class=\"list-upper-alpha\"><li>foo</li>" +
+        "<li><ol class=\"list-upper-alpha\"><li>^bar</li><ol></li></ol>";
+      var opts = {
+        comboItem: comboItem,
+        beforeHtml: beforeHtmlWithSelection,
+        afterHtml: afterHtmlWithSelection
+      };
+      this.assertComboBeforeAfter(opts);
+    },
+    "unapplying a simple style deeply": function() {
+      var comboItem = "List: A. B. C.";
+      var beforeHtmlWithSelection = "<ol class=\"list-upper-alpha\"><li>foo</li>" +
+        "<li><ol class=\"list-upper-alpha\"><li>^bar</li><ol></li></ol>";
+      var afterHtmlWithSelection = "<ol class=\"list-upper-alpha\"><li>foo</li>" +
+        "<li><ol><li>^bar</li><ol></li></ol>";
+
+      var opts = {
+        comboItem: comboItem,
+        beforeHtml: beforeHtmlWithSelection,
+        afterHtml: afterHtmlWithSelection
+      };
+      this.assertComboBeforeAfter(opts);
     }
   });
 })();

--- a/tests/structuredheadings/setnumberingstyletolist.js
+++ b/tests/structuredheadings/setnumberingstyletolist.js
@@ -135,10 +135,10 @@
     },
     "applying a simple style deeply": function() {
       var comboItem = "List: A. B. C.";
-      var beforeHtmlWithSelection = "<ol class=\"list-upper-alpha\"><li>foo</li>" +
-        "<li><ol><li>^bar</li><ol></li></ol>";
-      var afterHtmlWithSelection = "<ol class=\"list-upper-alpha\"><li>foo</li>" +
-        "<li><ol class=\"list-upper-alpha\"><li>^bar</li><ol></li></ol>";
+      var beforeHtmlWithSelection = "<ol class=\"list-upper-alpha\"><li>foo" +
+        "<ol><li>^bar</li></ol></li></ol>";
+      var afterHtmlWithSelection = "<ol class=\"list-upper-alpha\"><li>foo" +
+        "<ol class=\"list-upper-alpha\"><li>^bar</li></ol></li></ol>";
       var opts = {
         comboItem: comboItem,
         beforeHtml: beforeHtmlWithSelection,
@@ -148,10 +148,10 @@
     },
     "unapplying a simple style deeply": function() {
       var comboItem = "List: A. B. C.";
-      var beforeHtmlWithSelection = "<ol class=\"list-upper-alpha\"><li>foo</li>" +
-        "<li><ol class=\"list-upper-alpha\"><li>^bar</li><ol></li></ol>";
-      var afterHtmlWithSelection = "<ol class=\"list-upper-alpha\"><li>foo</li>" +
-        "<li><ol><li>^bar</li><ol></li></ol>";
+      var beforeHtmlWithSelection = "<ol class=\"list-upper-alpha\"><li>foo" +
+        "<ol class=\"list-upper-alpha\"><li>^bar</li></ol></li></ol>";
+      var afterHtmlWithSelection = "<ol class=\"list-upper-alpha\"><li>foo" +
+        "<ol><li>^bar</li></ol></li></ol>";
 
       var opts = {
         comboItem: comboItem,


### PR DESCRIPTION
fixes #86 by porting a really old change we had made to CKEditor core and forgotten about.  Now that we don't use the built in stylecombo plugin, this actually means one less forked change from core.  Woohoo 