### PR TITLE
Add list-decimal-point into allowed content list

### DIFF
--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -446,7 +446,7 @@
         title: "Numbering",
         toolbar: "styles,8",
         allowedContent: "h1(*); h2(*); h3(*); h4(*); h5(*); h6(*);" +
-          "ol(list-upper-alpha,list-lower-alpha,list-decimal,list-upper-roman,list-lower-roman)",
+          "ol(list-upper-alpha,list-lower-alpha,list-decimal,list-decimal-point,list-upper-roman,list-lower-roman)",
 
         panel: {
           css: [ CKEDITOR.skin.getPath("editor") ].concat(editor.config.contentsCss),


### PR DESCRIPTION
Follow up for https://github.com/PolicyStat/ckeditor-plugin-structured-headings/pull/90

Without this line, neither copy-paste with the new list style nor document load wouldn't work.