### PR TITLE
Remove decimal point lists support

### DIFF
--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -490,7 +490,7 @@
             editor.execCommand("applyHeadingPreset", value);
           }
 
-          if (value !== "restart" && value !== "clear") {structuredheadings/plugin.js
+          if (value !== "restart" && value !== "clear") {
             this.setValue(value);
           }
         },

--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -446,7 +446,7 @@
         title: "Numbering",
         toolbar: "styles,8",
         allowedContent: "h1(*); h2(*); h3(*); h4(*); h5(*); h6(*);" +
-          "ol(list-upper-alpha,list-lower-alpha,list-decimal,list-decimal-point,list-upper-roman,list-lower-roman)",
+          "ol(list-upper-alpha,list-lower-alpha,list-decimal,list-upper-roman,list-lower-roman)",
 
         panel: {
           css: [ CKEDITOR.skin.getPath("editor") ].concat(editor.config.contentsCss),
@@ -490,7 +490,7 @@
             editor.execCommand("applyHeadingPreset", value);
           }
 
-          if (value !== "restart" && value !== "clear") {
+          if (value !== "restart" && value !== "clear") {structuredheadings/plugin.js
             this.setValue(value);
           }
         },

--- a/tests/structuredheadings/formatcombo-boundaries.js
+++ b/tests/structuredheadings/formatcombo-boundaries.js
@@ -26,7 +26,7 @@
       bot.editor.plugins.structuredheadings.currentScheme = "1. a. i. a. i.";
       // this is the odd selection that occurs if you
       // triple click "foo"
-      bot.setHtmlWithSelection("<p>[foo</p><p>]bar</p>");
+      bot.setHtmlWithSelection("[<p>foo</p><p>bar</p>]");
 
 
       bot.combo(comboName, function (combo) {


### PR DESCRIPTION
Due to Customer Support requests, we should roll back changes in made in #91

Trello card: https://trello.com/c/zLr63CiI/795-unable-to-switch-to-bulleted-lists-within-a-decimal-list