### PR TITLE
Remove overlooked leftovers of list-decimal-point

### DIFF
--- a/structuredheadings/plugin.js
+++ b/structuredheadings/plugin.js
@@ -222,12 +222,6 @@
         attributes: {"class": "list-decimal"}
       }),
       //eslint-disable-next-line new-cap
-      "List: 1. 1. 1.": new CKEDITOR.style({
-        name: "List: 1. 1. 1.",
-        element: "ol",
-        attributes: {"class": "list-decimal-point"}
-      }),
-      //eslint-disable-next-line new-cap
       "List: I. II. III.": new CKEDITOR.style({
         name: "List: I. II. III.",
         element: "ol",

--- a/structuredheadings/styles/numbering.css
+++ b/structuredheadings/styles/numbering.css
@@ -178,20 +178,3 @@ body {
 .autonumber.autonumber-5.autonumber-r:before {
     content: counter(autonumber-5, lower-roman) ". ";
 }
-
-/*
-styles for List: 1. 1. 1.
-inspired by these:
-https://stackoverflow.com/questions/4098195/can-ordered-list-produce-result-that-looks-like-1-1-1-2-1-3-instead-of-just-1
-https://stackoverflow.com/questions/10405945/html-ordered-list-1-1-1-2-nested-counters-and-scope-not-working/10405962
-http://jsfiddle.net/qGCUk/4/
-*/
-ol.list-decimal-point, ol.list-decimal-point ol {
-    counter-reset: item
-}
-ol.list-decimal-point li {
-    display: block
-}
-ol.list-decimal-point li:before {
-    content: counters(item, ".") " "; counter-increment: item
-}


### PR DESCRIPTION
During https://github.com/PolicyStat/ckeditor-plugin-structured-headings/pull/92 I overlooked a few usages `list-decimal-point`